### PR TITLE
Open MediaPicker to select new avatar for upload

### DIFF
--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
@@ -6,6 +6,7 @@ import android.graphics.Color
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -59,6 +60,12 @@ internal fun GravatarScreen(
     val context = LocalContext.current
     var photoImageUri by rememberSaveable { mutableStateOf<Uri?>(null) }
 
+    val pickMedia = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickVisualMedia()
+    ) { uri ->
+        uri?.let { viewModel.onEvent(GravatarEvent.OnLocalImageSelected(uri)) }
+    }
+
     val uCropLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) {
@@ -106,6 +113,9 @@ internal fun GravatarScreen(
         uiState = uiState,
         onEvent = viewModel::onEvent,
         onTakePictureClicked = takePhotoCallback,
+        onPickMediaClicked = {
+            pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+        }
     )
 }
 
@@ -113,8 +123,9 @@ internal fun GravatarScreen(
 @Composable
 internal fun GravatarScreen(
     uiState: GravatarUiState,
+    onTakePictureClicked: () -> Unit,
+    onPickMediaClicked: () -> Unit,
     onEvent: (GravatarEvent) -> Unit = {},
-    onTakePictureClicked: () -> Unit = {},
 ) {
     Surface(
         modifier = Modifier.fillMaxSize(),
@@ -139,7 +150,7 @@ internal fun GravatarScreen(
                 ) {
                     UploadNewAvatarSection(
                         onTakePictureClicked = onTakePictureClicked,
-                        onChooseFromGalleryClicked = { }
+                        onChooseFromGalleryClicked = onPickMediaClicked,
                     )
                 }
                 if (uiState.isLoading) {
@@ -213,5 +224,7 @@ private fun GravatarScreenPreview() {
                 }
             }
         ),
+        onTakePictureClicked = { },
+        onPickMediaClicked = { },
     )
 }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
@@ -59,10 +59,12 @@ internal fun GravatarScreen(
     val lifecycle = LocalLifecycleOwner.current
     val context = LocalContext.current
     var photoImageUri by rememberSaveable { mutableStateOf<Uri?>(null) }
+    var mediaPickerLaunched by rememberSaveable { mutableStateOf(false) }
 
     val pickMedia = rememberLauncherForActivityResult(
         ActivityResultContracts.PickVisualMedia()
     ) { uri ->
+        mediaPickerLaunched = false
         uri?.let { viewModel.onEvent(GravatarEvent.OnLocalImageSelected(uri)) }
     }
 
@@ -114,7 +116,10 @@ internal fun GravatarScreen(
         onEvent = viewModel::onEvent,
         onTakePictureClicked = takePhotoCallback,
         onPickMediaClicked = {
-            pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+            if (!mediaPickerLaunched) {
+                pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+                mediaPickerLaunched = true
+            }
         }
     )
 }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
@@ -50,7 +50,10 @@ internal class GravatarViewModel(
                         currentState.copy(
                             avatars = buildList {
                                 add(avatar)
-                                addAll(currentState.avatars)
+                                addAll(
+                                    currentState.avatars
+                                        .filter { it.imageId != avatar.imageId }
+                                )
                             },
                             uploadingAvatar = null,
                         )

--- a/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreenTest.kt
+++ b/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreenTest.kt
@@ -25,7 +25,9 @@ class GravatarScreenTest : RoborazziTest() {
                     },
                     selectedAvatarId = "0"
                 ),
-                onEvent = { }
+                onEvent = { },
+                onTakePictureClicked = { },
+                onPickMediaClicked = { },
             )
         }
     }

--- a/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
+++ b/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
@@ -206,7 +206,7 @@ class GravatarViewModelTest {
             )
             assertEquals(
                 GravatarUiState(
-                    avatars = listOf(newAvatar) + avatars,
+                    avatars = listOf(newAvatar) + avatars.filter { it.imageId != newAvatar.imageId },
                     uploadingAvatar = null
                 ),
                 awaitItem()


### PR DESCRIPTION
### Description

A follow-up with the `Photos` button click handler. It opens the Media Picker.

There's one addition in the presentation logic when the image is uploaded. If we try to upload the same file twice, the backend will not create a new avatar but rather move it to the first place, which means we have to filter out the old one from the list, otherwise the `LazyList` will crash as it will have duplicated keys.

### Testing Steps

1. Launch the app
2. Tap `Photo` button
3. Pick an image and crop it
4. Confirm it was uploaded
5. Repeat it with the same image
6. Confirm there's no crash or duplicated avatars
