### PR TITLE
Avatar selection queue

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -44,7 +44,7 @@ style:
     excludeImports: []
   MaxLineLength:
     active: true
-    maxLineLength: 120
+    maxLineLength: 140
     excludePackageStatements: true
     excludeImportStatements: true
     excludeCommentStatements: false

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -26,19 +27,37 @@ internal class GravatarViewModel(
     private val _actions = Channel<GravatarAction>(Channel.BUFFERED)
     val actions = _actions.receiveAsFlow()
 
+    private val avatarSelectionQueue = Channel<String>(Channel.CONFLATED)
+
     init {
         fetchAvatars(isRefreshing = false)
+
+        viewModelScope.launch {
+            avatarSelectionQueue.receiveAsFlow()
+                .collectLatest { avatarId ->
+                    selectAvatar(avatarId)
+                }
+        }
     }
 
     fun onEvent(event: GravatarEvent) {
         when (event) {
             GravatarEvent.Refresh -> fetchAvatars(isRefreshing = true)
-            is GravatarEvent.OnAvatarSelected -> selectAvatar(event.avatarId)
+            is GravatarEvent.OnAvatarSelected -> addAvatarSelectionTOQueue(event.avatarId)
             is GravatarEvent.OnLocalImageSelected -> localImageSelected(event.uri)
             is GravatarEvent.OnImageCropped -> uploadAvatar(event.uri)
             GravatarEvent.OnFailedAvatarDialogDismissed -> dismissFailedUploadDialog()
             is GravatarEvent.OnFailedAvatarDismissed -> removedFailedUpload(event.uri)
             is GravatarEvent.OnFailedAvatarTapped -> showFailedUploadDialog(event.uri)
+        }
+    }
+
+    private fun addAvatarSelectionTOQueue(avatarId: String) {
+        val state = uiState.value
+        if (state.selectedAvatarId != avatarId || state.selectingAvatarId != avatarId) {
+            viewModelScope.launch {
+                avatarSelectionQueue.send(avatarId)
+            }
         }
     }
 
@@ -117,29 +136,31 @@ internal class GravatarViewModel(
         }
     }
 
-    private fun selectAvatar(avatarId: String) {
-        if (_uiState.value.selectedAvatarId != avatarId) {
-            viewModelScope.launch {
-                _uiState.update { currentState ->
-                    currentState.copy(selectingAvatarId = avatarId)
-                }
-                userRepository.selectAvatar(avatarId)
-                    .onSuccess {
-                        _uiState.update { currentState ->
-                            currentState.copy(
-                                selectingAvatarId = null,
-                                selectedAvatarId = avatarId,
-                            )
-                        }
-                    }
-                    .onFailure {
-                        _uiState.update { currentState ->
-                            currentState.copy(
-                                selectingAvatarId = null,
-                            )
-                        }
-                    }
+    private suspend fun selectAvatar(avatarId: String) {
+        if (uiState.value.selectedAvatarId == avatarId) {
+            _uiState.update { currentState ->
+                currentState.copy(selectingAvatarId = null)
             }
+        } else {
+            _uiState.update { currentState ->
+                currentState.copy(selectingAvatarId = avatarId)
+            }
+            userRepository.selectAvatar(avatarId)
+                .onSuccess {
+                    _uiState.update { currentState ->
+                        currentState.copy(
+                            selectingAvatarId = null,
+                            selectedAvatarId = avatarId,
+                        )
+                    }
+                }
+                .onFailure {
+                    _uiState.update { currentState ->
+                        currentState.copy(
+                            selectingAvatarId = null,
+                        )
+                    }
+                }
         }
     }
 

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
@@ -118,26 +118,28 @@ internal class GravatarViewModel(
     }
 
     private fun selectAvatar(avatarId: String) {
-        viewModelScope.launch {
-            _uiState.update { currentState ->
-                currentState.copy(selectingAvatarId = avatarId)
+        if (_uiState.value.selectedAvatarId != avatarId) {
+            viewModelScope.launch {
+                _uiState.update { currentState ->
+                    currentState.copy(selectingAvatarId = avatarId)
+                }
+                userRepository.selectAvatar(avatarId)
+                    .onSuccess {
+                        _uiState.update { currentState ->
+                            currentState.copy(
+                                selectingAvatarId = null,
+                                selectedAvatarId = avatarId,
+                            )
+                        }
+                    }
+                    .onFailure {
+                        _uiState.update { currentState ->
+                            currentState.copy(
+                                selectingAvatarId = null,
+                            )
+                        }
+                    }
             }
-            userRepository.selectAvatar(avatarId)
-                .onSuccess {
-                    _uiState.update { currentState ->
-                        currentState.copy(
-                            selectingAvatarId = null,
-                            selectedAvatarId = avatarId,
-                        )
-                    }
-                }
-                .onFailure {
-                    _uiState.update { currentState ->
-                        currentState.copy(
-                            selectingAvatarId = null,
-                        )
-                    }
-                }
         }
     }
 

--- a/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
+++ b/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
@@ -125,6 +125,31 @@ class GravatarViewModelTest {
     }
 
     @Test
+    fun `onEvent OnAvatarSelected shouldn't select the same avatar again`() = runTest {
+        // Given
+        val avatars = createAvatars()
+        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        initViewModel()
+        advanceUntilIdle()
+
+        val avatarId = "1"
+        coEvery { userRepository.selectAvatar(avatarId) } returns Result.success(Unit)
+        viewModel.onEvent(GravatarEvent.OnAvatarSelected(avatarId))
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            expectMostRecentItem()
+
+            // When
+            viewModel.onEvent(GravatarEvent.OnAvatarSelected(avatarId))
+
+            // Then
+            expectNoEvents()
+        }
+        coVerify(exactly = 1) { userRepository.selectAvatar(avatarId) }
+    }
+
+    @Test
     fun `onEvent OnAvatarSelected should handle failure`() = runTest {
         // Given
         val avatars = createAvatars()

--- a/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
+++ b/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
@@ -10,6 +10,7 @@ import com.gravatar.restapi.models.Avatar
 import com.gravatar.services.ErrorType
 import com.gravatar.services.GravatarResult
 import io.mockk.coEvery
+import io.mockk.coJustAwait
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -147,6 +148,49 @@ class GravatarViewModelTest {
             expectNoEvents()
         }
         coVerify(exactly = 1) { userRepository.selectAvatar(avatarId) }
+    }
+
+    @Test
+    fun `onEvent OnAvatarSelected should clean the loading state and skip selecting already selected avatar again`() = runTest {
+        // Given
+        val avatars = createAvatars()
+        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        initViewModel()
+        advanceUntilIdle()
+
+        val initialAvatarId = "1"
+        val otherAvatarId = "2"
+        coEvery { userRepository.selectAvatar(initialAvatarId) } returns Result.success(Unit)
+        coJustAwait { userRepository.selectAvatar(otherAvatarId) }
+        viewModel.onEvent(GravatarEvent.OnAvatarSelected(initialAvatarId))
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            expectMostRecentItem()
+
+            // When
+            viewModel.onEvent(GravatarEvent.OnAvatarSelected(otherAvatarId))
+            assertEquals(
+                GravatarUiState(
+                    avatars = avatars,
+                    selectedAvatarId = initialAvatarId,
+                    selectingAvatarId = otherAvatarId
+                ),
+                awaitItem()
+            )
+            viewModel.onEvent(GravatarEvent.OnAvatarSelected(initialAvatarId))
+
+            // Then
+            assertEquals(
+                GravatarUiState(
+                    avatars = avatars,
+                    selectedAvatarId = initialAvatarId,
+                    selectingAvatarId = null
+                ),
+                awaitItem()
+            )
+        }
+        coVerify(exactly = 1) { userRepository.selectAvatar(initialAvatarId) }
     }
 
     @Test


### PR DESCRIPTION
### Description

This PR adds a queue for the avatar selection event to make sure only the latest one is executed and those in progress are dropped. Additionally, this will now skip making an API call if the user tries to select an already selected avatar. 

Here's ther recording showing three scenarios: 
1. Selecting already selected avatar (Nothing happens)
2. Continuously selecting new ones while API call is in progress  (Only the last one is selected)
3. Continuously selecting new ones while API call is in progress **and at the end selecting an already selected one** (API calls are dropped and the state restored)


https://github.com/user-attachments/assets/67982efb-8943-48f9-ad4a-b6a88e09f1cb


### Testing Steps

1. Launch the app
2. Try selecting the already selected avatar
3. Try selecting multiple ones quickly - confirm only the last one is selected
4. Try selecting multiple ones quickly and end with the selected one - confirm the progress bar is gone and the selected avatar stays selected without loading.
