### PR TITLE
Store user profile locally - PART 1

### DIFF
--- a/app/src/main/java/com/gravatar/app/navigation/RootNavigation.kt
+++ b/app/src/main/java/com/gravatar/app/navigation/RootNavigation.kt
@@ -7,7 +7,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.gravatar.app.homeUi.presentation.home.HomeScreen
 import com.gravatar.app.loginUi.presentation.login.LoginScreen
-import com.gravatar.app.usercomponent.domain.repository.AuthRepository
+import com.gravatar.app.usercomponent.domain.usecase.IsUserLoggedIn
 import kotlinx.serialization.Serializable
 import org.koin.compose.koinInject
 
@@ -23,10 +23,10 @@ data object HomeDest
 @Composable
 fun RootNavigation() {
     val navController = rememberNavController()
-    val authRepository: AuthRepository = koinInject<AuthRepository>()
+    val isUserLoggedIn: IsUserLoggedIn = koinInject<IsUserLoggedIn>()
 
     LaunchedEffect(Unit) {
-        authRepository.isUserLoggedIn()
+        isUserLoggedIn()
             .collect { isLoggedIn ->
                 if (isLoggedIn) {
                     navController.navigate(HomeDest) {

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -45,19 +46,25 @@ import com.gravatar.app.homeUi.presentation.home.gravatar.components.GravatarHea
 import com.gravatar.app.homeUi.presentation.home.gravatar.components.UploadNewAvatarSection
 import com.gravatar.app.homeUi.presentation.home.gravatar.components.avatarSize
 import com.gravatar.app.homeUi.presentation.home.gravatar.components.avatarsGridSection
+import com.gravatar.app.usercomponent.domain.usecase.Logout
 import com.gravatar.restapi.models.Avatar
 import com.yalantis.ucrop.UCrop
 import com.yalantis.ucrop.UCropActivity
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
 import java.io.File
 import java.net.URI
+import kotlin.math.log
 
 @Composable
 internal fun GravatarScreen(
     viewModel: GravatarViewModel = koinViewModel()
 ) {
+    val logout = koinInject<Logout>()
+    val scope = rememberCoroutineScope()
     val uiState by viewModel.uiState.collectAsState()
     val lifecycle = LocalLifecycleOwner.current
     val context = LocalContext.current
@@ -123,6 +130,9 @@ internal fun GravatarScreen(
                 pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
                 mediaPickerLaunched = true
             }
+        },
+        onMenuClick = {
+            scope.launch { logout() }
         }
     )
 }
@@ -131,6 +141,7 @@ internal fun GravatarScreen(
 @Composable
 internal fun GravatarScreen(
     uiState: GravatarUiState,
+    onMenuClick: () -> Unit = {},
     onTakePictureClicked: () -> Unit,
     onPickMediaClicked: () -> Unit,
     onEvent: (GravatarEvent) -> Unit = {},
@@ -150,6 +161,7 @@ internal fun GravatarScreen(
                 GravatarHeader(
                     uiState.avatars.firstOrNull { it.imageId == uiState.selectedAvatarId },
                     modifier = Modifier.fillMaxWidth(),
+                    onMenuClick = onMenuClick,
                 )
                 LazyVerticalGrid(
                     columns = GridCells.Adaptive(minSize = avatarSize),

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
@@ -57,7 +57,6 @@ import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 import java.io.File
 import java.net.URI
-import kotlin.math.log
 
 @Composable
 internal fun GravatarScreen(

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/components/GravatarHeader.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/components/GravatarHeader.kt
@@ -32,6 +32,7 @@ import java.net.URI
 fun GravatarHeader(
     avatar: Avatar?,
     modifier: Modifier = Modifier,
+    onMenuClick: () -> Unit = {},
 ) {
     val avatarUrl = avatar?.imageUrl?.toString() ?: ""
 
@@ -66,7 +67,7 @@ fun GravatarHeader(
             )
             Spacer(modifier = Modifier.weight(1f))
             IconButton(
-                onClick = {},
+                onClick = onMenuClick,
                 modifier = Modifier
                     .align(Alignment.CenterVertically)
                     .size(44.dp)

--- a/loginUi/src/main/kotlin/com/gravatar/app/loginUi/presentation/login/LoginViewModel.kt
+++ b/loginUi/src/main/kotlin/com/gravatar/app/loginUi/presentation/login/LoginViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.gravatar.app.loginUi.presentation.oauth.OAuthConfig
 import com.gravatar.app.loginUi.presentation.oauth.OAuthResult
 import com.gravatar.app.usercomponent.domain.model.LoginRequest
-import com.gravatar.app.usercomponent.domain.repository.AuthRepository
+import com.gravatar.app.usercomponent.domain.usecase.Login
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 internal class LoginViewModel(
-    private val authRepository: AuthRepository,
+    private val login: Login,
     private val oAuthConfig: OAuthConfig
 ) : ViewModel() {
 
@@ -53,7 +53,7 @@ internal class LoginViewModel(
                 clientId = oAuthConfig.clientId
             )
 
-            authRepository.login(loginRequest)
+            login(loginRequest)
                 .onFailure { error ->
                     sendAction(LoginAction.ShowError)
                 }

--- a/userComponent/build.gradle.kts
+++ b/userComponent/build.gradle.kts
@@ -28,5 +28,6 @@ dependencies {
     testImplementation(libs.koin.test.junit4)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.mockk.android)
+    testImplementation(libs.turbine)
     testImplementation(project(":testUtils"))
 }

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/RealProfileRepository.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/RealProfileRepository.kt
@@ -1,0 +1,69 @@
+package com.gravatar.app.usercomponent.data
+
+import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
+import com.gravatar.restapi.models.Profile
+import com.gravatar.restapi.models.UpdateProfileRequest
+import com.gravatar.services.ProfileService
+import kotlinx.coroutines.flow.firstOrNull
+
+internal class RealProfileRepository(
+    private val profileService: ProfileService,
+    private val tokenStorage: AuthTokenStorage,
+) : ProfileRepository {
+
+    // Temporary in-memory storage for the profile
+    private var profile: Profile? = null
+
+    override suspend fun refreshUserProfile(): Result<Unit> {
+        return fetchProfile().fold(
+            onSuccess = {
+                Result.success(Unit)
+            },
+            onFailure = { error ->
+                Result.failure(error)
+            }
+        )
+    }
+
+    override suspend fun get(): Result<Profile> {
+        return if (profile != null) {
+            Result.success(profile!!)
+        } else {
+            fetchProfile()
+        }
+    }
+
+    override suspend fun update(updateRequest: UpdateProfileRequest): Result<Profile> {
+        val token = tokenStorage.get().firstOrNull()
+        return if (token != null) {
+            val result = profileService.updateProfileCatching(token, updateRequest).valueOrNull()
+            if (result != null) {
+                profile = result
+                Result.success(result)
+            } else {
+                Result.failure(IllegalStateException("Failed to update profile"))
+            }
+        } else {
+            Result.failure(IllegalStateException("User is not logged in"))
+        }
+    }
+
+    override suspend fun delete() {
+        profile = null
+    }
+
+    private suspend fun fetchProfile(): Result<Profile> {
+        val token = tokenStorage.get().firstOrNull()
+        if (token != null) {
+            val fetchedProfile = profileService.retrieveAuthenticatedCatching(withToken = token).valueOrNull()
+            return if (fetchedProfile != null) {
+                profile = fetchedProfile
+                Result.success(fetchedProfile)
+            } else {
+                Result.failure(IllegalStateException("Failed to fetch user profile"))
+            }
+        } else {
+            return Result.failure(IllegalStateException("User is not logged in"))
+        }
+    }
+}

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/RealUserRepository.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/RealUserRepository.kt
@@ -1,5 +1,6 @@
 package com.gravatar.app.usercomponent.data
 
+import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
 import com.gravatar.app.usercomponent.domain.repository.UserRepository
 import com.gravatar.restapi.models.Avatar
 import com.gravatar.restapi.models.Profile
@@ -7,22 +8,21 @@ import com.gravatar.restapi.models.UpdateProfileRequest
 import com.gravatar.services.AvatarService
 import com.gravatar.services.ErrorType
 import com.gravatar.services.GravatarResult
-import com.gravatar.services.ProfileService
 import com.gravatar.types.Hash
 import kotlinx.coroutines.flow.firstOrNull
 import java.io.File
 
 internal class RealUserRepository(
     private val avatarService: AvatarService,
-    private val profileService: ProfileService,
     private val tokenStorage: AuthTokenStorage,
+    private val profileRepository: ProfileRepository
 ) : UserRepository {
 
     override suspend fun selectAvatar(avatarId: String): Result<Unit> {
         val token = tokenStorage.get().firstOrNull()
         return if (token != null) {
-            val result = profileService.retrieveAuthenticatedCatching(token)
-                .valueOrNull()
+            val result = profileRepository.get()
+                .getOrNull()
                 ?.let { profile ->
                     avatarService.setAvatarCatching(
                         oauthToken = token,
@@ -43,8 +43,8 @@ internal class RealUserRepository(
     override suspend fun getAvatars(): Result<List<Avatar>> {
         val token = tokenStorage.get().firstOrNull()
         return if (token != null) {
-            val avatars = profileService.retrieveAuthenticatedCatching(token)
-                .valueOrNull()
+            val avatars = profileRepository.get()
+                .getOrNull()
                 ?.let { profile ->
                     avatarService.retrieveCatching(
                         oauthToken = token,
@@ -62,38 +62,18 @@ internal class RealUserRepository(
     }
 
     override suspend fun getProfile(): Result<Profile> {
-        val token = tokenStorage.get().firstOrNull()
-        return if (token != null) {
-            val profile = profileService.retrieveAuthenticatedCatching(token).valueOrNull()
-            if (profile != null) {
-                Result.success(profile)
-            } else {
-                Result.failure(IllegalStateException("Failed to retrieve profile"))
-            }
-        } else {
-            Result.failure(IllegalStateException("User is not logged in"))
-        }
+        return profileRepository.get()
     }
 
     override suspend fun updateProfile(updateRequest: UpdateProfileRequest): Result<Profile> {
-        val token = tokenStorage.get().firstOrNull()
-        return if (token != null) {
-            val result = profileService.updateProfileCatching(token, updateRequest).valueOrNull()
-            if (result != null) {
-                Result.success(result)
-            } else {
-                Result.failure(IllegalStateException("Failed to update profile"))
-            }
-        } else {
-            Result.failure(IllegalStateException("User is not logged in"))
-        }
+        return profileRepository.update(updateRequest)
     }
 
     override suspend fun uploadAvatar(avatarFile: File): GravatarResult<Avatar, ErrorType> {
         val token = tokenStorage.get().firstOrNull()
         return if (token != null) {
-            profileService.retrieveAuthenticatedCatching(token)
-                .valueOrNull()
+            profileRepository.get()
+                .getOrNull()
                 ?.let { profile ->
                     avatarService.uploadCatching(
                         file = avatarFile,

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/UserComponentModule.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/UserComponentModule.kt
@@ -1,17 +1,21 @@
 package com.gravatar.app.usercomponent.di
 
 import com.gravatar.app.usercomponent.data.RealAuthRepository
+import com.gravatar.app.usercomponent.data.RealProfileRepository
 import com.gravatar.app.usercomponent.data.RealUserRepository
 import com.gravatar.app.usercomponent.data.WordPressClient
 import com.gravatar.app.usercomponent.domain.repository.AuthRepository
+import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
 import com.gravatar.app.usercomponent.domain.repository.UserRepository
 import com.gravatar.services.AvatarService
 import com.gravatar.services.ProfileService
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.factoryOf
+import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
 val userComponentModule = module {
+    singleOf(::RealProfileRepository) { bind<ProfileRepository>() }
     factoryOf(::RealAuthRepository) { bind<AuthRepository>() }
     factoryOf(::RealUserRepository) { bind<UserRepository>() }
     factoryOf(::WordPressClient)

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/UserComponentModule.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/UserComponentModule.kt
@@ -7,6 +7,12 @@ import com.gravatar.app.usercomponent.data.WordPressClient
 import com.gravatar.app.usercomponent.domain.repository.AuthRepository
 import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
 import com.gravatar.app.usercomponent.domain.repository.UserRepository
+import com.gravatar.app.usercomponent.domain.usecase.IsUserLoggedIn
+import com.gravatar.app.usercomponent.domain.usecase.IsUserLoggedInUseCase
+import com.gravatar.app.usercomponent.domain.usecase.Login
+import com.gravatar.app.usercomponent.domain.usecase.LoginUseCase
+import com.gravatar.app.usercomponent.domain.usecase.Logout
+import com.gravatar.app.usercomponent.domain.usecase.LogoutUseCase
 import com.gravatar.services.AvatarService
 import com.gravatar.services.ProfileService
 import org.koin.core.module.dsl.bind
@@ -18,6 +24,9 @@ val userComponentModule = module {
     singleOf(::RealProfileRepository) { bind<ProfileRepository>() }
     factoryOf(::RealAuthRepository) { bind<AuthRepository>() }
     factoryOf(::RealUserRepository) { bind<UserRepository>() }
+    factoryOf(::LoginUseCase) { bind<Login>() }
+    factoryOf(::LogoutUseCase) { bind<Logout>() }
+    factoryOf(::IsUserLoggedInUseCase) { bind<IsUserLoggedIn>() }
     factoryOf(::WordPressClient)
     single { ProfileService() }
     single { AvatarService() }

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/repository/AuthRepository.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/repository/AuthRepository.kt
@@ -3,7 +3,7 @@ package com.gravatar.app.usercomponent.domain.repository
 import com.gravatar.app.usercomponent.domain.model.LoginRequest
 import kotlinx.coroutines.flow.Flow
 
-interface AuthRepository {
+internal interface AuthRepository {
 
     suspend fun login(loginRequest: LoginRequest): Result<Unit>
 

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/repository/ProfileRepository.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/repository/ProfileRepository.kt
@@ -1,0 +1,15 @@
+package com.gravatar.app.usercomponent.domain.repository
+
+import com.gravatar.restapi.models.Profile
+import com.gravatar.restapi.models.UpdateProfileRequest
+
+internal interface ProfileRepository {
+
+    suspend fun refreshUserProfile(): Result<Unit>
+
+    suspend fun get(): Result<Profile>
+
+    suspend fun update(updateRequest: UpdateProfileRequest): Result<Profile>
+
+    suspend fun delete()
+}

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/IsUserLoggedInUseCase.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/IsUserLoggedInUseCase.kt
@@ -1,0 +1,16 @@
+package com.gravatar.app.usercomponent.domain.usecase
+
+import com.gravatar.app.usercomponent.domain.repository.AuthRepository
+import kotlinx.coroutines.flow.Flow
+
+internal class IsUserLoggedInUseCase(
+    private val authRepository: AuthRepository,
+) : IsUserLoggedIn {
+    override fun invoke(): Flow<Boolean> {
+        return authRepository.isUserLoggedIn()
+    }
+}
+
+interface IsUserLoggedIn {
+    operator fun invoke(): Flow<Boolean>
+}

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/LoginUseCase.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/LoginUseCase.kt
@@ -1,0 +1,22 @@
+package com.gravatar.app.usercomponent.domain.usecase
+
+import com.gravatar.app.usercomponent.domain.model.LoginRequest
+import com.gravatar.app.usercomponent.domain.repository.AuthRepository
+import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
+
+interface Login {
+    suspend operator fun invoke(loginRequest: LoginRequest): Result<Unit>
+}
+
+internal class LoginUseCase(
+    val authRepository: AuthRepository,
+    val profileRepository: ProfileRepository,
+) : Login {
+
+    override suspend fun invoke(loginRequest: LoginRequest): Result<Unit> {
+        return authRepository.login(loginRequest)
+            .onSuccess {
+                profileRepository.refreshUserProfile()
+            }
+    }
+}

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/LoginUseCase.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/LoginUseCase.kt
@@ -9,8 +9,8 @@ interface Login {
 }
 
 internal class LoginUseCase(
-    val authRepository: AuthRepository,
-    val profileRepository: ProfileRepository,
+    private val authRepository: AuthRepository,
+    private val profileRepository: ProfileRepository,
 ) : Login {
 
     override suspend fun invoke(loginRequest: LoginRequest): Result<Unit> {

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/LogoutUseCase.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/LogoutUseCase.kt
@@ -1,0 +1,18 @@
+package com.gravatar.app.usercomponent.domain.usecase
+
+import com.gravatar.app.usercomponent.domain.repository.AuthRepository
+import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
+
+internal class LogoutUseCase(
+    private val authRepository: AuthRepository,
+    private val profileRepository: ProfileRepository,
+) : Logout {
+    override suspend fun invoke() {
+        profileRepository.delete()
+        authRepository.logout()
+    }
+}
+
+interface Logout {
+    suspend operator fun invoke()
+}

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/RealProfileRepositoryTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/RealProfileRepositoryTest.kt
@@ -1,0 +1,248 @@
+package com.gravatar.app.usercomponent.data
+
+import com.gravatar.app.testUtils.CoroutineTestRule
+import com.gravatar.restapi.models.Profile
+import com.gravatar.restapi.models.UpdateProfileRequest
+import com.gravatar.services.GravatarResult
+import com.gravatar.services.ProfileService
+import com.gravatar.services.ErrorType
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.net.URI
+
+@ExperimentalCoroutinesApi
+class RealProfileRepositoryTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    var coroutineTestRule = CoroutineTestRule(testDispatcher)
+
+    private lateinit var repository: RealProfileRepository
+    private val profileService = mockk<ProfileService>()
+    private val tokenStorage = FakeAuthTokenStorage()
+
+    private val testToken = "test-token"
+
+    @Before
+    fun setup() {
+        repository = RealProfileRepository(
+            profileService = profileService,
+            tokenStorage = tokenStorage
+        )
+    }
+
+    @Test
+    fun `refreshUserProfile should return success when user is logged in and service returns success`() = runTest {
+        // Given
+        val profile = createTestProfile()
+        tokenStorage.save(testToken)
+
+        val profileResult = GravatarResult.Success<Profile, ErrorType>(profile)
+        coEvery { profileService.retrieveAuthenticatedCatching(testToken) } returns profileResult
+
+        // When
+        val result = repository.refreshUserProfile()
+
+        // Then
+        assertTrue(result.isSuccess)
+        coVerify { profileService.retrieveAuthenticatedCatching(testToken) }
+    }
+
+    @Test
+    fun `refreshUserProfile should return failure when user is not logged in`() = runTest {
+        // Given
+        tokenStorage.clear()
+
+        // When
+        val result = repository.refreshUserProfile()
+
+        // Then
+        assertTrue(result.isFailure)
+
+        // Verify no interactions with service
+        coVerify(exactly = 0) { profileService.retrieveAuthenticatedCatching(any()) }
+    }
+
+    @Test
+    fun `refreshUserProfile should return failure when service returns null`() = runTest {
+        // Given
+        tokenStorage.save(testToken)
+
+        val profileResult = GravatarResult.Failure<Profile, ErrorType>(ErrorType.Server)
+        coEvery { profileService.retrieveAuthenticatedCatching(testToken) } returns profileResult
+
+        // When
+        val result = repository.refreshUserProfile()
+
+        // Then
+        assertTrue(result.isFailure)
+
+        coVerify { profileService.retrieveAuthenticatedCatching(testToken) }
+    }
+
+    @Test
+    fun `get should return cached profile when available`() = runTest {
+        // Given
+        val profile = createTestProfile()
+        tokenStorage.save(testToken)
+
+        // First call to populate the cache
+        val profileResult = GravatarResult.Success<Profile, ErrorType>(profile)
+        coEvery { profileService.retrieveAuthenticatedCatching(testToken) } returns profileResult
+        repository.refreshUserProfile()
+
+        // When
+        val result = repository.get()
+
+        // Then
+        assertTrue(result.isSuccess)
+        assertEquals(profile, result.getOrNull())
+
+        // Verify service was not called again
+        coVerify(exactly = 1) { profileService.retrieveAuthenticatedCatching(any()) }
+    }
+
+    @Test
+    fun `get should fetch profile when cache is empty`() = runTest {
+        // Given
+        val profile = createTestProfile()
+        tokenStorage.save(testToken)
+
+        val profileResult = GravatarResult.Success<Profile, ErrorType>(profile)
+        coEvery { profileService.retrieveAuthenticatedCatching(testToken) } returns profileResult
+
+        // When
+        val result = repository.get()
+
+        // Then
+        assertTrue(result.isSuccess)
+        assertEquals(profile, result.getOrNull())
+
+        coVerify { profileService.retrieveAuthenticatedCatching(testToken) }
+    }
+
+    @Test
+    fun `get should return failure when user is not logged in`() = runTest {
+        // Given
+        tokenStorage.clear()
+
+        // When
+        val result = repository.get()
+
+        // Then
+        assertTrue(result.isFailure)
+
+        // Verify no interactions with service
+        coVerify(exactly = 0) { profileService.retrieveAuthenticatedCatching(any()) }
+    }
+
+    @Test
+    fun `update should return success when user is logged in and service returns success`() = runTest {
+        // Given
+        val profile = createTestProfile()
+        val updateRequest = UpdateProfileRequest {
+            displayName = "New Name"
+        }
+        tokenStorage.save(testToken)
+
+        val profileResult = GravatarResult.Success<Profile, ErrorType>(profile)
+        coEvery { profileService.updateProfileCatching(testToken, updateRequest) } returns profileResult
+
+        // When
+        val result = repository.update(updateRequest)
+
+        // Then
+        assertTrue(result.isSuccess)
+        assertEquals(profile, result.getOrNull())
+
+        coVerify { profileService.updateProfileCatching(testToken, updateRequest) }
+    }
+
+    @Test
+    fun `update should return failure when user is not logged in`() = runTest {
+        // Given
+        val updateRequest = UpdateProfileRequest {
+            displayName = "New Name"
+        }
+        tokenStorage.clear()
+
+        // When
+        val result = repository.update(updateRequest)
+
+        // Then
+        assertTrue(result.isFailure)
+
+        // Verify no interactions with service
+        coVerify(exactly = 0) { profileService.updateProfileCatching(any(), any()) }
+    }
+
+    @Test
+    fun `update should return failure when service returns null`() = runTest {
+        // Given
+        val updateRequest = UpdateProfileRequest {
+            displayName = "New Name"
+        }
+        tokenStorage.save(testToken)
+
+        val profileResult = GravatarResult.Failure<Profile, ErrorType>(ErrorType.Server)
+        coEvery { profileService.updateProfileCatching(testToken, updateRequest) } returns profileResult
+
+        // When
+        val result = repository.update(updateRequest)
+
+        // Then
+        assertTrue(result.isFailure)
+
+        coVerify { profileService.updateProfileCatching(testToken, updateRequest) }
+    }
+
+    @Test
+    fun `delete should clear cached profile`() = runTest {
+        // Given
+        val profile = createTestProfile()
+        tokenStorage.save(testToken)
+
+        // First populate the cache
+        val profileResult = GravatarResult.Success<Profile, ErrorType>(profile)
+        coEvery { profileService.retrieveAuthenticatedCatching(testToken) } returns profileResult
+        repository.get()
+
+        // When
+        repository.delete()
+
+        // Then - verify that get() now has to fetch from service again
+        coEvery { profileService.retrieveAuthenticatedCatching(testToken) } returns profileResult
+        repository.get()
+
+        // Verify service was called twice (once before delete and once after)
+        coVerify(exactly = 2) { profileService.retrieveAuthenticatedCatching(testToken) }
+    }
+
+    private fun createTestProfile(): Profile {
+        return Profile {
+            hash = "test-hash"
+            displayName = "Test User"
+            profileUrl = URI.create("https://example.com/profile")
+            avatarUrl = URI.create("https://example.com/avatar")
+            avatarAltText = ""
+            location = "Test Location"
+            description = "Test Description"
+            jobTitle = "Test Job"
+            company = "Test Company"
+            verifiedAccounts = emptyList()
+            pronouns = "they/them"
+            pronunciation = "Test Pronunciation"
+        }
+    }
+}

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/RealProfileRepositoryTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/RealProfileRepositoryTest.kt
@@ -3,14 +3,13 @@ package com.gravatar.app.usercomponent.data
 import com.gravatar.app.testUtils.CoroutineTestRule
 import com.gravatar.restapi.models.Profile
 import com.gravatar.restapi.models.UpdateProfileRequest
+import com.gravatar.services.ErrorType
 import com.gravatar.services.GravatarResult
 import com.gravatar.services.ProfileService
-import com.gravatar.services.ErrorType
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/RealUserRepositoryTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/RealUserRepositoryTest.kt
@@ -152,7 +152,7 @@ class RealUserRepositoryTest {
             val profileResult = Result.success(profile)
             coEvery { profileRepository.get() } returns profileResult
 
-            // Mock avatar serviceL
+            // Mock avatar service
             val avatarResult = GravatarResult.Success<Unit, ErrorType>(Unit)
             coEvery {
                 avatarService.setAvatarCatching(

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/RealUserRepositoryTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/RealUserRepositoryTest.kt
@@ -1,13 +1,13 @@
 package com.gravatar.app.usercomponent.data
 
 import com.gravatar.app.testUtils.CoroutineTestRule
+import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
 import com.gravatar.restapi.models.Avatar
 import com.gravatar.restapi.models.Profile
 import com.gravatar.restapi.models.UpdateProfileRequest
 import com.gravatar.services.AvatarService
 import com.gravatar.services.ErrorType
 import com.gravatar.services.GravatarResult
-import com.gravatar.services.ProfileService
 import com.gravatar.types.Hash
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -33,7 +33,7 @@ class RealUserRepositoryTest {
 
     private lateinit var repository: RealUserRepository
     private val avatarService = mockk<AvatarService>()
-    private val profileService = mockk<ProfileService>()
+    private val profileRepository = mockk<ProfileRepository>()
     private val tokenStorage = FakeAuthTokenStorage()
 
     private val testToken = "test-token"
@@ -43,7 +43,7 @@ class RealUserRepositoryTest {
     fun setup() {
         repository = RealUserRepository(
             avatarService = avatarService,
-            profileService = profileService,
+            profileRepository = profileRepository,
             tokenStorage = tokenStorage
         )
     }
@@ -59,8 +59,8 @@ class RealUserRepositoryTest {
             tokenStorage.save(testToken)
 
             // Mock profile service
-            val profileResult = GravatarResult.Success<Profile, ErrorType>(profile)
-            coEvery { profileService.retrieveAuthenticatedCatching(testToken) } returns profileResult
+            val profileResult = Result.success(profile)
+            coEvery { profileRepository.get() } returns profileResult
 
             // Mock avatar service
             val avatarResult = GravatarResult.Success<List<Avatar>, ErrorType>(avatars)
@@ -76,7 +76,7 @@ class RealUserRepositoryTest {
             assertEquals(avatars, result.getOrNull())
 
             // Verify interactions
-            coVerify { profileService.retrieveAuthenticatedCatching(testToken) }
+            coVerify { profileRepository.get() }
             coVerify { avatarService.retrieveCatching(testToken, any<Hash>()) }
         }
 
@@ -95,7 +95,7 @@ class RealUserRepositoryTest {
         assertEquals("User is not logged in", exception?.message)
 
         // Verify no interactions with services
-        coVerify(exactly = 0) { profileService.retrieveAuthenticatedCatching(any()) }
+        coVerify(exactly = 0) { profileRepository.get() }
         coVerify(exactly = 0) {
             avatarService.retrieveCatching(
                 any(),
@@ -109,9 +109,8 @@ class RealUserRepositoryTest {
         runTest {
             // Given
             val profile = createTestProfile()
-            tokenStorage.save(testToken)
-            val profileResult = GravatarResult.Success<Profile, ErrorType>(profile)
-            coEvery { profileService.retrieveAuthenticatedCatching(testToken) } returns profileResult
+            val profileResult = Result.success(profile)
+            coEvery { profileRepository.get() } returns profileResult
 
             // When
             val result = repository.getProfile()
@@ -119,33 +118,15 @@ class RealUserRepositoryTest {
             // Then
             assertTrue(result.isSuccess)
             assertEquals(profile, result.getOrNull())
-            coVerify { profileService.retrieveAuthenticatedCatching(testToken) }
+            coVerify { profileRepository.get() }
         }
-
-    @Test
-    fun `getProfile should return failure when user is not logged in`() = runTest {
-        // Given
-        tokenStorage.clear()
-
-        // When
-        val result = repository.getProfile()
-
-        // Then
-        assertTrue(result.isFailure)
-        val exception = result.exceptionOrNull()
-        assertTrue(exception is IllegalStateException)
-        assertEquals("User is not logged in", exception?.message)
-        coVerify(exactly = 0) { profileService.retrieveAuthenticatedCatching(any()) }
-    }
 
     @Test
     fun `getProfile should return failure when retrieveAuthenticatedCatching returns null profile`() =
         runTest {
             // Given
-            tokenStorage.save(testToken)
-            val profileResult = mockk<GravatarResult<Profile, ErrorType>>()
-            coEvery { profileResult.valueOrNull() } returns null
-            coEvery { profileService.retrieveAuthenticatedCatching(testToken) } returns profileResult
+            val profileResult = Result.failure<Profile>(IllegalStateException("Test exception"))
+            coEvery { profileRepository.get() } returns profileResult
 
             // When
             val result = repository.getProfile()
@@ -154,8 +135,7 @@ class RealUserRepositoryTest {
             assertTrue(result.isFailure)
             val exception = result.exceptionOrNull()
             assertTrue(exception is IllegalStateException)
-            assertEquals("Failed to retrieve profile", exception?.message)
-            coVerify { profileService.retrieveAuthenticatedCatching(testToken) }
+            coVerify { profileRepository.get() }
         }
 
     @Test
@@ -169,10 +149,10 @@ class RealUserRepositoryTest {
             tokenStorage.save(testToken)
 
             // Mock profile service
-            val profileResult = GravatarResult.Success<Profile, ErrorType>(profile)
-            coEvery { profileService.retrieveAuthenticatedCatching(testToken) } returns profileResult
+            val profileResult = Result.success(profile)
+            coEvery { profileRepository.get() } returns profileResult
 
-            // Mock avatar service
+            // Mock avatar serviceL
             val avatarResult = GravatarResult.Success<Unit, ErrorType>(Unit)
             coEvery {
                 avatarService.setAvatarCatching(
@@ -189,7 +169,7 @@ class RealUserRepositoryTest {
             assertTrue(result.isSuccess)
 
             // Verify interactions
-            coVerify { profileService.retrieveAuthenticatedCatching(testToken) }
+            coVerify { profileRepository.get() }
             coVerify {
                 avatarService.setAvatarCatching(
                     hash = testHash,
@@ -215,7 +195,7 @@ class RealUserRepositoryTest {
         assertEquals("User is not logged in", exception?.message)
 
         // Verify no interactions with services
-        coVerify(exactly = 0) { profileService.retrieveAuthenticatedCatching(any()) }
+        coVerify(exactly = 0) { profileRepository.get() }
         coVerify(exactly = 0) { avatarService.setAvatarCatching(any(), any(), any()) }
     }
 
@@ -225,10 +205,8 @@ class RealUserRepositoryTest {
         val avatarId = "test-avatar-id"
         tokenStorage.save(testToken)
 
-        // Mock profile service to return null
-        val profileResult = mockk<GravatarResult<Profile, ErrorType>>()
-        coEvery { profileResult.valueOrNull() } returns null
-        coEvery { profileService.retrieveAuthenticatedCatching(testToken) } returns profileResult
+        val profileResult = Result.failure<Profile>(IllegalStateException("Test exception"))
+        coEvery { profileRepository.get() } returns profileResult
 
         // When
         val result = repository.selectAvatar(avatarId)
@@ -237,10 +215,9 @@ class RealUserRepositoryTest {
         assertTrue(result.isFailure)
         val exception = result.exceptionOrNull()
         assertTrue(exception is IllegalStateException)
-        assertEquals("Failed to select avatar", exception?.message)
 
         // Verify interactions
-        coVerify { profileService.retrieveAuthenticatedCatching(testToken) }
+        coVerify { profileRepository.get() }
         coVerify(exactly = 0) { avatarService.setAvatarCatching(any(), any(), any()) }
     }
 
@@ -254,8 +231,8 @@ class RealUserRepositoryTest {
         tokenStorage.save(testToken)
 
         // Mock profile service
-        val profileResult = GravatarResult.Success<Profile, ErrorType>(profile)
-        coEvery { profileService.retrieveAuthenticatedCatching(testToken) } returns profileResult
+        val profileResult = Result.success(profile)
+        coEvery { profileRepository.get() } returns profileResult
 
         // Mock avatar service to return a result that is not a Success
         val avatarResult = mockk<GravatarResult<Unit, ErrorType>>()
@@ -278,7 +255,7 @@ class RealUserRepositoryTest {
         assertEquals("Failed to select avatar", exception?.message)
 
         // Verify interactions
-        coVerify { profileService.retrieveAuthenticatedCatching(testToken) }
+        coVerify { profileRepository.get() }
         coVerify {
             avatarService.setAvatarCatching(
                 hash = testHash,
@@ -289,19 +266,13 @@ class RealUserRepositoryTest {
     }
 
     @Test
-    fun `updateProfile should return success when user is logged in and service returns success`() =
+    fun `updateProfile should return success when profileRepository returns success`() =
         runTest {
             // Given
             val updateRequest = UpdateProfileRequest { }
             val updatedProfile = createTestProfile()
-            tokenStorage.save(testToken)
-            val profileResult = GravatarResult.Success<Profile, ErrorType>(updatedProfile)
-            coEvery {
-                profileService.updateProfileCatching(
-                    testToken,
-                    updateRequest
-                )
-            } returns profileResult
+            val profileResult = Result.success(updatedProfile)
+            coEvery { profileRepository.update(updateRequest) } returns profileResult
 
             // When
             val result = repository.updateProfile(updateRequest)
@@ -309,39 +280,16 @@ class RealUserRepositoryTest {
             // Then
             assertTrue(result.isSuccess)
             assertEquals(updatedProfile, result.getOrNull())
-            coVerify { profileService.updateProfileCatching(testToken, updateRequest) }
+            coVerify { profileRepository.update(updateRequest) }
         }
 
     @Test
-    fun `updateProfile should return failure when user is not logged in`() = runTest {
+    fun `updateProfile should return failure when profileRepository fails`() = runTest {
         // Given
         val updateRequest = UpdateProfileRequest { }
-        tokenStorage.clear()
-
-        // When
-        val result = repository.updateProfile(updateRequest)
-
-        // Then
-        assertTrue(result.isFailure)
-        val exception = result.exceptionOrNull()
-        assertTrue(exception is IllegalStateException)
-        assertEquals("User is not logged in", exception?.message)
-        coVerify(exactly = 0) { profileService.updateProfileCatching(any(), any()) }
-    }
-
-    @Test
-    fun `updateProfile should return failure when updateProfileCatching fails`() = runTest {
-        // Given
-        val updateRequest = UpdateProfileRequest { }
-        tokenStorage.save(testToken)
-        val profileResult = mockk<GravatarResult<Profile, ErrorType>>()
-        coEvery { profileResult.valueOrNull() } returns null
         coEvery {
-            profileService.updateProfileCatching(
-                testToken,
-                updateRequest
-            )
-        } returns profileResult
+            profileRepository.update(updateRequest)
+        } returns Result.failure(IllegalStateException("Test exception"))
 
         // When
         val result = repository.updateProfile(updateRequest)
@@ -350,8 +298,6 @@ class RealUserRepositoryTest {
         assertTrue(result.isFailure)
         val exception = result.exceptionOrNull()
         assertTrue(exception is IllegalStateException)
-        assertEquals("Failed to update profile", exception?.message)
-        coVerify { profileService.updateProfileCatching(testToken, updateRequest) }
     }
 
     @Test
@@ -366,8 +312,8 @@ class RealUserRepositoryTest {
             tokenStorage.save(testToken)
 
             // Mock profile service
-            val profileResult = GravatarResult.Success<Profile, ErrorType>(profile)
-            coEvery { profileService.retrieveAuthenticatedCatching(testToken) } returns profileResult
+            val profileResult = Result.success(profile)
+            coEvery { profileRepository.get() } returns profileResult
 
             // Mock avatar service
             val avatarResult = GravatarResult.Success<Avatar, ErrorType>(uploadedAvatar)
@@ -409,19 +355,19 @@ class RealUserRepositoryTest {
         assertTrue(result is GravatarResult.Failure)
 
         // Verify no interactions with services
-        coVerify(exactly = 0) { profileService.retrieveAuthenticatedCatching(any()) }
+        coVerify(exactly = 0) { profileRepository.get() }
         coVerify(exactly = 0) { avatarService.uploadCatching(any(), any(), any()) }
     }
 
     @Test
-    fun `uploadAvatar should return failure when profile service returns null`() = runTest {
+    fun `uploadAvatar should return failure when profileRepository returns null`() = runTest {
         // Given
         val testFile = mockk<File>()
         tokenStorage.save(testToken)
 
         // Mock profile service to return null
-        val profileResult = GravatarResult.Failure<Profile, ErrorType>(ErrorType.Server)
-        coEvery { profileService.retrieveAuthenticatedCatching(testToken) } returns profileResult
+        val profileResult = Result.failure<Profile>(IllegalStateException("Test exception"))
+        coEvery { profileRepository.get() } returns profileResult
 
         // When
         val result = repository.uploadAvatar(testFile)
@@ -430,7 +376,7 @@ class RealUserRepositoryTest {
         assertTrue(result is GravatarResult.Failure)
 
         // Verify interactions
-        coVerify { profileService.retrieveAuthenticatedCatching(testToken) }
+        coVerify { profileRepository.get() }
         coVerify(exactly = 0) { avatarService.uploadCatching(any(), any(), any()) }
     }
 
@@ -444,8 +390,8 @@ class RealUserRepositoryTest {
         tokenStorage.save(testToken)
 
         // Mock profile service
-        val profileResult = GravatarResult.Success<Profile, ErrorType>(profile)
-        coEvery { profileService.retrieveAuthenticatedCatching(testToken) } returns profileResult
+        val profileResult = Result.success(profile)
+        coEvery { profileRepository.get() } returns profileResult
 
         // Mock avatar service to return a result that is not a Success
         val avatarResult = GravatarResult.Failure<Avatar, ErrorType>(ErrorType.Server)
@@ -464,7 +410,7 @@ class RealUserRepositoryTest {
         assertTrue(result is GravatarResult.Failure)
 
         // Verify interactions
-        coVerify { profileService.retrieveAuthenticatedCatching(testToken) }
+        coVerify { profileRepository.get() }
         coVerify {
             avatarService.uploadCatching(
                 file = testFile,

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/IsUserLoggedInUseCaseTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/IsUserLoggedInUseCaseTest.kt
@@ -1,0 +1,48 @@
+package com.gravatar.app.usercomponent.domain.usecase
+
+import app.cash.turbine.test
+import com.gravatar.app.testUtils.CoroutineTestRule
+import com.gravatar.app.usercomponent.domain.repository.AuthRepository
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class IsUserLoggedInUseCaseTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    var coroutineTestRule = CoroutineTestRule(testDispatcher)
+
+    private lateinit var isUserLoggedInUseCase: IsUserLoggedInUseCase
+    private val authRepository = mockk<AuthRepository>()
+
+    @Before
+    fun setup() {
+        isUserLoggedInUseCase = IsUserLoggedInUseCase(
+            authRepository = authRepository
+        )
+    }
+
+    @Test
+    fun `invoke should return flow from authRepository isUserLoggedIn when user is logged in`() = runTest {
+        // Given
+        val isLoggedInFlow = flowOf(true, false)
+        every { authRepository.isUserLoggedIn() } returns isLoggedInFlow
+
+        // When
+        isUserLoggedInUseCase().test {
+            assertEquals(true, awaitItem())
+            assertEquals(false, awaitItem())
+            awaitComplete()
+        }
+    }
+}

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/LoginUseCaseTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/LoginUseCaseTest.kt
@@ -1,0 +1,93 @@
+package com.gravatar.app.usercomponent.domain.usecase
+
+import com.gravatar.app.testUtils.CoroutineTestRule
+import com.gravatar.app.usercomponent.domain.model.LoginRequest
+import com.gravatar.app.usercomponent.domain.repository.AuthRepository
+import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class LoginUseCaseTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    var coroutineTestRule = CoroutineTestRule(testDispatcher)
+
+    private lateinit var loginUseCase: LoginUseCase
+    private val authRepository = mockk<AuthRepository>()
+    private val profileRepository = mockk<ProfileRepository>()
+
+    private val testLoginRequest = LoginRequest(
+        code = "test-code",
+        clientSecret = "test-client-secret",
+        redirectUri = "test-redirect-uri",
+        clientId = "test-client-id"
+    )
+
+    @Before
+    fun setup() {
+        loginUseCase = LoginUseCase(
+            authRepository = authRepository,
+            profileRepository = profileRepository
+        )
+    }
+
+    @Test
+    fun `login should return success when authRepository login succeeds`() = runTest {
+        // Given
+        val loginResult = Result.success(Unit)
+        coEvery { authRepository.login(testLoginRequest) } returns loginResult
+        coEvery { profileRepository.refreshUserProfile() } returns Result.success(Unit)
+
+        // When
+        val result = loginUseCase.invoke(testLoginRequest)
+
+        // Then
+        assertTrue(result.isSuccess)
+        coVerify { authRepository.login(testLoginRequest) }
+        coVerify { profileRepository.refreshUserProfile() }
+    }
+
+    @Test
+    fun `login should return failure when authRepository login fails`() = runTest {
+        // Given
+        val loginResult = Result.failure<Unit>(RuntimeException("Login failed"))
+        coEvery { authRepository.login(testLoginRequest) } returns loginResult
+
+        // When
+        val result = loginUseCase.invoke(testLoginRequest)
+
+        // Then
+        assertTrue(result.isFailure)
+        coVerify { authRepository.login(testLoginRequest) }
+        coVerify(exactly = 0) { profileRepository.refreshUserProfile() }
+    }
+
+    @Test
+    fun `login should return success when refresh profile fails`() = runTest {
+        // Given
+        val loginResult = Result.success(Unit)
+        coEvery { authRepository.login(testLoginRequest) } returns loginResult
+        coEvery {
+            profileRepository.refreshUserProfile()
+        } returns Result.failure(IllegalStateException("Profile refresh failed"))
+
+        // When
+        val result = loginUseCase.invoke(testLoginRequest)
+
+        // Then
+        assertTrue(result.isSuccess)
+        coVerify { authRepository.login(testLoginRequest) }
+        coVerify { profileRepository.refreshUserProfile() }
+    }
+}

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/LogoutUseCaseTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/LogoutUseCaseTest.kt
@@ -1,0 +1,56 @@
+package com.gravatar.app.usercomponent.domain.usecase
+
+import com.gravatar.app.testUtils.CoroutineTestRule
+import com.gravatar.app.usercomponent.domain.repository.AuthRepository
+import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifySequence
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class LogoutUseCaseTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    var coroutineTestRule = CoroutineTestRule(testDispatcher)
+
+    private lateinit var logoutUseCase: LogoutUseCase
+    private val authRepository = mockk<AuthRepository>()
+    private val profileRepository = mockk<ProfileRepository>()
+
+    @Before
+    fun setup() {
+        logoutUseCase = LogoutUseCase(
+            authRepository = authRepository,
+            profileRepository = profileRepository
+        )
+
+        // Set up default behavior for mocks
+        coEvery { profileRepository.delete() } returns Unit
+        coEvery { authRepository.logout() } returns Unit
+    }
+
+    @Test
+    fun `invoke should call profileRepository delete and authRepository logout in correct order`() = runTest {
+        // When
+        logoutUseCase.invoke()
+
+        // Then
+        coVerify(exactly = 1) { profileRepository.delete() }
+        coVerify(exactly = 1) { authRepository.logout() }
+
+        // Verify order of calls
+        coVerifySequence {
+            profileRepository.delete()
+            authRepository.logout()
+        }
+    }
+}


### PR DESCRIPTION
### Description

This is the first PR out of 2 for the local profile storage. 

This one creates a new `ProfileRepository` to handle the mediation logic between the remote and local Profile data sources. 

Temporarily, it holds the `Profile` property to serve as an in-memory local storage, but that will be handled by a proper storage framework in the next PR.

The idea here is that we will rely mostly on the locally cached profile and only update when requested. Such requests can come from different events: profile update on one of the screens, or we could also decide to call a refresh on each app startup. 

Additionally, I've introduced three use cases: Login/Logout/IsUserLoggedIn. The logic when logging in/out now requires more actions than just storing/clearing the user token, so we needed a place outside the `AuthRepository` to do that. This means the `AuthRepository` can now be internal.

### Testing Steps

1. Launch the app and make sure all works as before
2. You can verify the login-logout scenario - I've added a Logout action in the Gravatar tab.
3. An easy way to see a difference is when you launch the app and wait for the profile to load. Then switch to the Profile tab - it shows the data instantly. 
