### PR TITLE
Fix wrong recomposition when orientation changes

### DIFF
--- a/app/src/main/java/com/gravatar/app/navigation/RootNavigation.kt
+++ b/app/src/main/java/com/gravatar/app/navigation/RootNavigation.kt
@@ -2,6 +2,7 @@ package com.gravatar.app.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -29,23 +30,9 @@ fun RootNavigation() {
         isUserLoggedIn()
             .collect { isLoggedIn ->
                 if (isLoggedIn) {
-                    navController.navigate(HomeDest) {
-                        popUpTo(SplashDest) {
-                            inclusive = true
-                            saveState = true
-                        }
-                        launchSingleTop = true
-                        restoreState = true
-                    }
+                    navController.navigateSavingState(HomeDest)
                 } else {
-                    navController.navigate(LoginDest) {
-                        popUpTo(SplashDest) {
-                            inclusive = true
-                            saveState = true
-                        }
-                        launchSingleTop = true
-                        restoreState = true
-                    }
+                    navController.navigateSavingState(LoginDest)
                 }
             }
     }
@@ -58,5 +45,16 @@ fun RootNavigation() {
         composable<HomeDest> {
             HomeScreen()
         }
+    }
+}
+
+private fun NavHostController.navigateSavingState(destination: Any) {
+    navigate(destination) {
+        popUpTo(SplashDest) {
+            inclusive = true
+            saveState = true
+        }
+        launchSingleTop = true
+        restoreState = true
     }
 }

--- a/app/src/main/java/com/gravatar/app/navigation/RootNavigation.kt
+++ b/app/src/main/java/com/gravatar/app/navigation/RootNavigation.kt
@@ -30,7 +30,12 @@ fun RootNavigation() {
             .collect { isLoggedIn ->
                 if (isLoggedIn) {
                     navController.navigate(HomeDest) {
-                        popUpTo(SplashDest) { inclusive = true }
+                        popUpTo(SplashDest) {
+                            inclusive = true
+                            saveState = true
+                        }
+                        launchSingleTop = true
+                        restoreState = true
                     }
                 } else {
                     navController.navigate(LoginDest) {

--- a/app/src/main/java/com/gravatar/app/navigation/RootNavigation.kt
+++ b/app/src/main/java/com/gravatar/app/navigation/RootNavigation.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.gravatar.app.homeUi.presentation.home.HomeScreen
 import com.gravatar.app.loginUi.presentation.login.LoginScreen
@@ -12,49 +13,68 @@ import com.gravatar.app.usercomponent.domain.usecase.IsUserLoggedIn
 import kotlinx.serialization.Serializable
 import org.koin.compose.koinInject
 
-@Serializable
-data object SplashDest
-
-@Serializable
-data object LoginDest
-
-@Serializable
-data object HomeDest
-
 @Composable
 fun RootNavigation() {
     val navController = rememberNavController()
+    val backStackEntry = navController.currentBackStackEntryAsState()
     val isUserLoggedIn: IsUserLoggedIn = koinInject<IsUserLoggedIn>()
 
     LaunchedEffect(Unit) {
         isUserLoggedIn()
             .collect { isLoggedIn ->
+                val lastRoute = backStackEntry.value?.destination?.route?.let {
+                    RootDestination.fromRoute(it)
+                } ?: RootDestination.Splash
+
                 if (isLoggedIn) {
-                    navController.navigateSavingState(HomeDest)
+                    navController.navigateSavingState(RootDestination.Home, popTo = lastRoute)
                 } else {
-                    navController.navigateSavingState(LoginDest)
+                    navController.navigateSavingState(RootDestination.Login, popTo = lastRoute)
                 }
             }
     }
-    NavHost(navController = navController, startDestination = SplashDest) {
-        composable<SplashDest> {
+
+    NavHost(navController = navController, startDestination = RootDestination.Splash) {
+        composable<RootDestination.Splash> {
         }
-        composable<LoginDest> {
+        composable<RootDestination.Login> {
             LoginScreen()
         }
-        composable<HomeDest> {
+        composable<RootDestination.Home> {
             HomeScreen()
         }
     }
 }
 
-private fun NavHostController.navigateSavingState(destination: Any) {
+private fun NavHostController.navigateSavingState(destination: Any, popTo: Any) {
     navigate(destination) {
-        popUpTo(SplashDest) {
+        popUpTo(popTo) {
             inclusive = true
             saveState = true
         }
         launchSingleTop = true
         restoreState = true
+    }
+}
+
+internal sealed class RootDestination {
+    @Serializable
+    data object Splash : RootDestination()
+
+    @Serializable
+    data object Login : RootDestination()
+
+    @Serializable
+    data object Home : RootDestination()
+
+    companion object {
+        fun fromRoute(route: String): RootDestination? {
+            return when (route) {
+                Splash::class.qualifiedName -> Splash
+                Login::class.qualifiedName -> Login
+                Home::class.qualifiedName -> Home
+                else -> null
+            }
+        }
     }
 }

--- a/app/src/main/java/com/gravatar/app/navigation/RootNavigation.kt
+++ b/app/src/main/java/com/gravatar/app/navigation/RootNavigation.kt
@@ -39,7 +39,12 @@ fun RootNavigation() {
                     }
                 } else {
                     navController.navigate(LoginDest) {
-                        popUpTo(SplashDest) { inclusive = true }
+                        popUpTo(SplashDest) {
+                            inclusive = true
+                            saveState = true
+                        }
+                        launchSingleTop = true
+                        restoreState = true
                     }
                 }
             }


### PR DESCRIPTION
### Description

When the orientation changed, we were losing the state. That was because we weren't saving the state in the RootNavigation.

<del>⚠️ This PR fixes that problem; however, it introduces a minor issue related to the back button. After an orientation change, the backButton is not handled by the nested NavGraph (`HomeScreen`) and it's received in the first NavGraph (`RootNavigation`). At the moment, it's not a big deal because it dismisses the app instead of moving the Gravatar Tab (in case you are not already on it). 
I would say that's something Compose is not doing well, and I haven't found a straightforward solution for it.  (If you have any ideas, please let me know)</del>

<del>Solving the wrong recomposition has higher priority than the back button, but of course, we'll need to find a proper solution. Wdty?</del>

Solved in [f21f1d7](https://github.com/Automattic/Gravatar-Android/pull/35/commits/f21f1d7ef31b4cef7536fab7d180d09afd28b2b3)

### Testing Steps

- Launch the app
- Navigate to the Profile Tab
- Rotate the device to force an orientation change
- Verify after the rotation that you are still on the Profile Tab (you can also verify that if you edit any fields, the states will be preserved)
