### PR TITLE
UserSession persistence to keep and emit user logged in state

### DIFF
--- a/app/src/main/java/com/gravatar/app/di/DispatcherModule.kt
+++ b/app/src/main/java/com/gravatar/app/di/DispatcherModule.kt
@@ -2,7 +2,9 @@ package com.gravatar.app.di
 
 import com.gravatar.app.foundations.DispatcherProvider
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import org.koin.dsl.module
 
 val dispatcherModule = module {
@@ -12,6 +14,9 @@ val dispatcherModule = module {
             io = Dispatchers.IO,
             default = Dispatchers.Default
         )
+    }
+    single<CoroutineScope> {
+        CoroutineScope(SupervisorJob() + get<DispatcherProvider>().default)
     }
 }
 

--- a/app/src/main/java/com/gravatar/app/navigation/RootNavigation.kt
+++ b/app/src/main/java/com/gravatar/app/navigation/RootNavigation.kt
@@ -9,6 +9,8 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.gravatar.app.homeUi.presentation.home.HomeScreen
 import com.gravatar.app.loginUi.presentation.login.LoginScreen
+import com.gravatar.app.usercomponent.domain.model.UserSession.LOGGED_IN
+import com.gravatar.app.usercomponent.domain.model.UserSession.LOGGED_OUT
 import com.gravatar.app.usercomponent.domain.usecase.IsUserLoggedIn
 import kotlinx.serialization.Serializable
 import org.koin.compose.koinInject
@@ -21,15 +23,14 @@ fun RootNavigation() {
 
     LaunchedEffect(Unit) {
         isUserLoggedIn()
-            .collect { isLoggedIn ->
+            .collect { userSession ->
                 val lastRoute = backStackEntry.value?.destination?.route?.let {
                     RootDestination.fromRoute(it)
                 } ?: RootDestination.Splash
 
-                if (isLoggedIn) {
-                    navController.navigateSavingState(RootDestination.Home, popTo = lastRoute)
-                } else {
-                    navController.navigateSavingState(RootDestination.Login, popTo = lastRoute)
+                when (userSession) {
+                    LOGGED_IN -> navController.navigateSavingState(RootDestination.Home, popTo = lastRoute)
+                    LOGGED_OUT -> navController.navigateSavingState(RootDestination.Login, popTo = lastRoute)
                 }
             }
     }

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/AuthTokenStorage.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/AuthTokenStorage.kt
@@ -1,19 +1,19 @@
 package com.gravatar.app.usercomponent.data
 
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.IOException
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.gravatar.app.foundations.DispatcherProvider
 import com.gravatar.app.usercomponent.di.UserPrefs
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 
 internal interface AuthTokenStorage {
-    fun get(): Flow<String?>
+    suspend fun get(): String?
 
     suspend fun save(token: String)
 
@@ -31,13 +31,17 @@ internal class DatastoreAuthTokenStorage(
 
     private val tokenKey = stringPreferencesKey(KEY)
 
-    override fun get(): Flow<String?> {
-        return dataStore.data
-            .map { preferences ->
-                preferences[tokenKey]
-            }
-            .catch { emit(null) }
-            .flowOn(dispatcherProvider.io)
+    override suspend fun get(): String? {
+        return try {
+            dataStore.data
+                .map { preferences ->
+                    preferences[tokenKey]
+                }
+                .flowOn(dispatcherProvider.io)
+                .firstOrNull()
+        } catch (_: IOException) {
+            null
+        }
     }
 
     override suspend fun save(token: String): Unit = withContext(dispatcherProvider.io) {

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/InMemoryUserSessionPersistence.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/InMemoryUserSessionPersistence.kt
@@ -1,0 +1,40 @@
+package com.gravatar.app.usercomponent.data
+
+import com.gravatar.app.foundations.DispatcherProvider
+import com.gravatar.app.usercomponent.domain.model.UserSession
+import com.gravatar.app.usercomponent.domain.repository.AuthRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+
+internal class InMemoryUserSessionPersistence(
+    authRepository: AuthRepository,
+    applicationScope: CoroutineScope,
+    dispatcherProvider: DispatcherProvider,
+) : UserSessionPersistence {
+
+    private val _state: MutableSharedFlow<UserSession> = MutableSharedFlow(replay = 1)
+    override val state: Flow<UserSession> = _state
+
+    init {
+        applicationScope.launch(dispatcherProvider.io) {
+            val initialSession = if (authRepository.isUserLoggedIn()) {
+                UserSession.LOGGED_IN
+            } else {
+                UserSession.LOGGED_OUT
+            }
+            _state.emit(initialSession)
+        }
+    }
+
+    override suspend fun set(session: UserSession) {
+        _state.emit(session)
+    }
+}
+
+internal interface UserSessionPersistence {
+    val state: Flow<UserSession>
+
+    suspend fun set(session: UserSession)
+}

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/RealAuthRepository.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/RealAuthRepository.kt
@@ -2,8 +2,6 @@ package com.gravatar.app.usercomponent.data
 
 import com.gravatar.app.usercomponent.domain.model.LoginRequest
 import com.gravatar.app.usercomponent.domain.repository.AuthRepository
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 
 internal class RealAuthRepository(
     private val wordPressClient: WordPressClient,
@@ -24,7 +22,7 @@ internal class RealAuthRepository(
         )
     }
 
-    override fun isUserLoggedIn(): Flow<Boolean> = tokenStorage.get().map { it != null }
+    override suspend fun isUserLoggedIn(): Boolean = tokenStorage.get() != null
 
     override suspend fun logout() {
         tokenStorage.clear()

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/RealProfileRepository.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/RealProfileRepository.kt
@@ -6,7 +6,6 @@ import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
 import com.gravatar.restapi.models.Profile
 import com.gravatar.restapi.models.UpdateProfileRequest
 import com.gravatar.services.ProfileService
-import kotlinx.coroutines.flow.firstOrNull
 
 internal class RealProfileRepository(
     private val profileService: ProfileService,
@@ -35,7 +34,7 @@ internal class RealProfileRepository(
     }
 
     override suspend fun update(updateRequest: UpdateProfileRequest): Result<Profile> {
-        val token = tokenStorage.get().firstOrNull()
+        val token = tokenStorage.get()
         return if (token != null) {
             val result = profileService.updateProfileCatching(token, updateRequest).valueOrNull()
             if (result != null) {
@@ -54,7 +53,7 @@ internal class RealProfileRepository(
     }
 
     private suspend fun fetchProfile(): Result<Profile> {
-        val token = tokenStorage.get().firstOrNull()
+        val token = tokenStorage.get()
         if (token != null) {
             val fetchedProfile = profileService.retrieveAuthenticatedCatching(withToken = token).valueOrNull()
             return if (fetchedProfile != null) {

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/RealUserRepository.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/RealUserRepository.kt
@@ -87,7 +87,7 @@ internal class RealUserRepository(
     }
 
     override suspend fun deleteAvatar(avatarId: String): Result<Unit> {
-        val token = tokenStorage.get().firstOrNull()
+        val token = tokenStorage.get()
         return if (token != null) {
             when (val result = avatarService.deleteAvatarCatching(avatarId, token)) {
                 is GravatarResult.Success -> {

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/RealUserRepository.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/RealUserRepository.kt
@@ -9,7 +9,6 @@ import com.gravatar.services.AvatarService
 import com.gravatar.services.ErrorType
 import com.gravatar.services.GravatarResult
 import com.gravatar.types.Hash
-import kotlinx.coroutines.flow.firstOrNull
 import java.io.File
 
 internal class RealUserRepository(
@@ -19,7 +18,7 @@ internal class RealUserRepository(
 ) : UserRepository {
 
     override suspend fun selectAvatar(avatarId: String): Result<Unit> {
-        val token = tokenStorage.get().firstOrNull()
+        val token = tokenStorage.get()
         return if (token != null) {
             val result = profileRepository.get()
                 .getOrNull()
@@ -41,7 +40,7 @@ internal class RealUserRepository(
     }
 
     override suspend fun getAvatars(): Result<List<Avatar>> {
-        val token = tokenStorage.get().firstOrNull()
+        val token = tokenStorage.get()
         return if (token != null) {
             val avatars = profileRepository.get()
                 .getOrNull()
@@ -70,7 +69,7 @@ internal class RealUserRepository(
     }
 
     override suspend fun uploadAvatar(avatarFile: File): GravatarResult<Avatar, ErrorType> {
-        val token = tokenStorage.get().firstOrNull()
+        val token = tokenStorage.get()
         return if (token != null) {
             profileRepository.get()
                 .getOrNull()

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/UserComponentModule.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/UserComponentModule.kt
@@ -1,8 +1,10 @@
 package com.gravatar.app.usercomponent.di
 
+import com.gravatar.app.usercomponent.data.InMemoryUserSessionPersistence
 import com.gravatar.app.usercomponent.data.RealAuthRepository
 import com.gravatar.app.usercomponent.data.RealProfileRepository
 import com.gravatar.app.usercomponent.data.RealUserRepository
+import com.gravatar.app.usercomponent.data.UserSessionPersistence
 import com.gravatar.app.usercomponent.data.WordPressClient
 import com.gravatar.app.usercomponent.domain.repository.AuthRepository
 import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
@@ -17,6 +19,7 @@ import com.gravatar.services.AvatarService
 import com.gravatar.services.ProfileService
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.factoryOf
+import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
 val userComponentModule = module {
@@ -27,6 +30,7 @@ val userComponentModule = module {
     factoryOf(::LogoutUseCase) { bind<Logout>() }
     factoryOf(::IsUserLoggedInUseCase) { bind<IsUserLoggedIn>() }
     factoryOf(::WordPressClient)
+    singleOf(::InMemoryUserSessionPersistence) { bind<UserSessionPersistence>() }
     single { ProfileService() }
     single { AvatarService() }
     includes(httpClientModule)

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/model/UserSession.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/model/UserSession.kt
@@ -1,0 +1,5 @@
+package com.gravatar.app.usercomponent.domain.model
+
+enum class UserSession {
+    LOGGED_IN, LOGGED_OUT
+}

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/repository/AuthRepository.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/repository/AuthRepository.kt
@@ -1,13 +1,12 @@
 package com.gravatar.app.usercomponent.domain.repository
 
 import com.gravatar.app.usercomponent.domain.model.LoginRequest
-import kotlinx.coroutines.flow.Flow
 
 internal interface AuthRepository {
 
     suspend fun login(loginRequest: LoginRequest): Result<Unit>
 
-    fun isUserLoggedIn(): Flow<Boolean>
+    suspend fun isUserLoggedIn(): Boolean
 
     suspend fun logout()
 }

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/IsUserLoggedInUseCase.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/IsUserLoggedInUseCase.kt
@@ -1,16 +1,17 @@
 package com.gravatar.app.usercomponent.domain.usecase
 
-import com.gravatar.app.usercomponent.domain.repository.AuthRepository
+import com.gravatar.app.usercomponent.data.UserSessionPersistence
+import com.gravatar.app.usercomponent.domain.model.UserSession
 import kotlinx.coroutines.flow.Flow
 
 internal class IsUserLoggedInUseCase(
-    private val authRepository: AuthRepository,
+    private val userSessionPersistence: UserSessionPersistence,
 ) : IsUserLoggedIn {
-    override fun invoke(): Flow<Boolean> {
-        return authRepository.isUserLoggedIn()
+    override fun invoke(): Flow<UserSession> {
+        return userSessionPersistence.state
     }
 }
 
 interface IsUserLoggedIn {
-    operator fun invoke(): Flow<Boolean>
+    operator fun invoke(): Flow<UserSession>
 }

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/LoginUseCase.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/LoginUseCase.kt
@@ -1,6 +1,8 @@
 package com.gravatar.app.usercomponent.domain.usecase
 
+import com.gravatar.app.usercomponent.data.UserSessionPersistence
 import com.gravatar.app.usercomponent.domain.model.LoginRequest
+import com.gravatar.app.usercomponent.domain.model.UserSession
 import com.gravatar.app.usercomponent.domain.repository.AuthRepository
 import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
 
@@ -11,12 +13,14 @@ interface Login {
 internal class LoginUseCase(
     private val authRepository: AuthRepository,
     private val profileRepository: ProfileRepository,
+    private val userSessionPersistence: UserSessionPersistence,
 ) : Login {
 
     override suspend fun invoke(loginRequest: LoginRequest): Result<Unit> {
         return authRepository.login(loginRequest)
             .onSuccess {
                 profileRepository.refreshUserProfile()
+                userSessionPersistence.set(UserSession.LOGGED_IN)
             }
     }
 }

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/LogoutUseCase.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/LogoutUseCase.kt
@@ -1,15 +1,19 @@
 package com.gravatar.app.usercomponent.domain.usecase
 
+import com.gravatar.app.usercomponent.data.UserSessionPersistence
+import com.gravatar.app.usercomponent.domain.model.UserSession
 import com.gravatar.app.usercomponent.domain.repository.AuthRepository
 import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
 
 internal class LogoutUseCase(
     private val authRepository: AuthRepository,
     private val profileRepository: ProfileRepository,
+    private val userSessionPersistence: UserSessionPersistence,
 ) : Logout {
     override suspend fun invoke() {
         profileRepository.delete()
         authRepository.logout()
+        userSessionPersistence.set(UserSession.LOGGED_OUT)
     }
 }
 

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/FakeAuthTokenStorage.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/FakeAuthTokenStorage.kt
@@ -1,14 +1,11 @@
 package com.gravatar.app.usercomponent.data
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-
 class FakeAuthTokenStorage : AuthTokenStorage {
 
     private var authToken: String? = null
 
-    override fun get(): Flow<String?> {
-        return flow { emit(authToken) }
+    override suspend fun get(): String? {
+        return authToken
     }
 
     override suspend fun save(token: String) {

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/InMemoryUserSessionPersistenceTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/InMemoryUserSessionPersistenceTest.kt
@@ -1,0 +1,107 @@
+package com.gravatar.app.usercomponent.data
+
+import app.cash.turbine.test
+import com.gravatar.app.foundations.DispatcherProvider
+import com.gravatar.app.testUtils.CoroutineTestRule
+import com.gravatar.app.usercomponent.domain.model.UserSession
+import com.gravatar.app.usercomponent.domain.repository.AuthRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class InMemoryUserSessionPersistenceTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    var coroutineTestRule = CoroutineTestRule(testDispatcher)
+
+    private lateinit var userSessionPersistence: InMemoryUserSessionPersistence
+    private val authRepository = mockk<AuthRepository>()
+    private val applicationScope = CoroutineScope(testDispatcher)
+    private val testDispatcherProvider = object : DispatcherProvider {
+        override val main: CoroutineDispatcher = testDispatcher
+        override val io: CoroutineDispatcher = testDispatcher
+        override val default: CoroutineDispatcher = testDispatcher
+    }
+
+    @Before
+    fun setup() {
+        // Default setup, will be overridden in specific tests
+        coEvery { authRepository.isUserLoggedIn() } returns false
+    }
+
+    @Test
+    fun `initial state should be LOGGED_IN when user is logged in`() = runTest {
+        // Given
+        coEvery { authRepository.isUserLoggedIn() } returns true
+
+        // When
+        userSessionPersistence = InMemoryUserSessionPersistence(
+            authRepository = authRepository,
+            applicationScope = applicationScope,
+            dispatcherProvider = testDispatcherProvider
+        )
+
+        // Then
+        userSessionPersistence.state.test {
+            assertEquals(UserSession.LOGGED_IN, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `initial state should be LOGGED_OUT when user is not logged in`() = runTest {
+        // Given
+        coEvery { authRepository.isUserLoggedIn() } returns false
+
+        // When
+        userSessionPersistence = InMemoryUserSessionPersistence(
+            authRepository = authRepository,
+            applicationScope = applicationScope,
+            dispatcherProvider = testDispatcherProvider
+        )
+
+        // Then
+        userSessionPersistence.state.test {
+            assertEquals(UserSession.LOGGED_OUT, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `set should update the state`() = runTest {
+        // Given
+        coEvery { authRepository.isUserLoggedIn() } returns false
+        userSessionPersistence = InMemoryUserSessionPersistence(
+            authRepository = authRepository,
+            applicationScope = applicationScope,
+            dispatcherProvider = testDispatcherProvider
+        )
+
+        // When & Then
+        userSessionPersistence.state.test {
+            // Initial state
+            assertEquals(UserSession.LOGGED_OUT, awaitItem())
+
+            // Set new state
+            userSessionPersistence.set(UserSession.LOGGED_IN)
+            assertEquals(UserSession.LOGGED_IN, awaitItem())
+
+            // Set another state
+            userSessionPersistence.set(UserSession.LOGGED_OUT)
+            assertEquals(UserSession.LOGGED_OUT, awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/di/UserComponentModuleTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/di/UserComponentModuleTest.kt
@@ -1,7 +1,9 @@
 package com.gravatar.app.usercomponent.di
 
 import com.gravatar.app.foundations.DispatcherProvider
+import com.gravatar.app.usercomponent.data.InMemoryUserSessionPersistence
 import com.gravatar.app.usercomponent.data.WordPressClient
+import kotlinx.coroutines.CoroutineScope
 import org.junit.Test
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.test.KoinTest
@@ -16,7 +18,8 @@ class UserComponentModuleTest : KoinTest {
     fun checkAllModules() {
         userComponentModule.verify(
             injections = injectedParameters(
-                definition<WordPressClient>(DispatcherProvider::class)
+                definition<WordPressClient>(DispatcherProvider::class),
+                definition<InMemoryUserSessionPersistence>(CoroutineScope::class, DispatcherProvider::class)
             )
         )
     }

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/IsUserLoggedInUseCaseTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/IsUserLoggedInUseCaseTest.kt
@@ -2,7 +2,8 @@ package com.gravatar.app.usercomponent.domain.usecase
 
 import app.cash.turbine.test
 import com.gravatar.app.testUtils.CoroutineTestRule
-import com.gravatar.app.usercomponent.domain.repository.AuthRepository
+import com.gravatar.app.usercomponent.data.UserSessionPersistence
+import com.gravatar.app.usercomponent.domain.model.UserSession
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -23,25 +24,25 @@ class IsUserLoggedInUseCaseTest {
     var coroutineTestRule = CoroutineTestRule(testDispatcher)
 
     private lateinit var isUserLoggedInUseCase: IsUserLoggedInUseCase
-    private val authRepository = mockk<AuthRepository>()
+    private val userSessionPersistence = mockk<UserSessionPersistence>()
 
     @Before
     fun setup() {
         isUserLoggedInUseCase = IsUserLoggedInUseCase(
-            authRepository = authRepository
+            userSessionPersistence = userSessionPersistence
         )
     }
 
     @Test
     fun `invoke should return flow from authRepository isUserLoggedIn when user is logged in`() = runTest {
         // Given
-        val isLoggedInFlow = flowOf(true, false)
-        every { authRepository.isUserLoggedIn() } returns isLoggedInFlow
+        val isLoggedInFlow = flowOf(UserSession.LOGGED_IN, UserSession.LOGGED_OUT)
+        every { userSessionPersistence.state } returns isLoggedInFlow
 
         // When
         isUserLoggedInUseCase().test {
-            assertEquals(true, awaitItem())
-            assertEquals(false, awaitItem())
+            assertEquals(UserSession.LOGGED_IN, awaitItem())
+            assertEquals(UserSession.LOGGED_OUT, awaitItem())
             awaitComplete()
         }
     }

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/LoginUseCaseTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/LoginUseCaseTest.kt
@@ -1,7 +1,9 @@
 package com.gravatar.app.usercomponent.domain.usecase
 
 import com.gravatar.app.testUtils.CoroutineTestRule
+import com.gravatar.app.usercomponent.data.UserSessionPersistence
 import com.gravatar.app.usercomponent.domain.model.LoginRequest
+import com.gravatar.app.usercomponent.domain.model.UserSession
 import com.gravatar.app.usercomponent.domain.repository.AuthRepository
 import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
 import io.mockk.coEvery
@@ -26,6 +28,7 @@ class LoginUseCaseTest {
     private lateinit var loginUseCase: LoginUseCase
     private val authRepository = mockk<AuthRepository>()
     private val profileRepository = mockk<ProfileRepository>()
+    private val userSessionPersistence = mockk<UserSessionPersistence>()
 
     private val testLoginRequest = LoginRequest(
         code = "test-code",
@@ -38,8 +41,10 @@ class LoginUseCaseTest {
     fun setup() {
         loginUseCase = LoginUseCase(
             authRepository = authRepository,
-            profileRepository = profileRepository
+            profileRepository = profileRepository,
+            userSessionPersistence = userSessionPersistence,
         )
+        coEvery { userSessionPersistence.set(any()) } returns Unit
     }
 
     @Test
@@ -56,6 +61,7 @@ class LoginUseCaseTest {
         assertTrue(result.isSuccess)
         coVerify { authRepository.login(testLoginRequest) }
         coVerify { profileRepository.refreshUserProfile() }
+        coVerify { userSessionPersistence.set(UserSession.LOGGED_IN) }
     }
 
     @Test
@@ -71,6 +77,7 @@ class LoginUseCaseTest {
         assertTrue(result.isFailure)
         coVerify { authRepository.login(testLoginRequest) }
         coVerify(exactly = 0) { profileRepository.refreshUserProfile() }
+        coVerify(exactly = 0) { userSessionPersistence.set(UserSession.LOGGED_IN) }
     }
 
     @Test
@@ -89,5 +96,6 @@ class LoginUseCaseTest {
         assertTrue(result.isSuccess)
         coVerify { authRepository.login(testLoginRequest) }
         coVerify { profileRepository.refreshUserProfile() }
+        coVerify { userSessionPersistence.set(UserSession.LOGGED_IN) }
     }
 }

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/LogoutUseCaseTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/LogoutUseCaseTest.kt
@@ -1,6 +1,8 @@
 package com.gravatar.app.usercomponent.domain.usecase
 
 import com.gravatar.app.testUtils.CoroutineTestRule
+import com.gravatar.app.usercomponent.data.UserSessionPersistence
+import com.gravatar.app.usercomponent.domain.model.UserSession
 import com.gravatar.app.usercomponent.domain.repository.AuthRepository
 import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
 import io.mockk.coEvery
@@ -25,17 +27,20 @@ class LogoutUseCaseTest {
     private lateinit var logoutUseCase: LogoutUseCase
     private val authRepository = mockk<AuthRepository>()
     private val profileRepository = mockk<ProfileRepository>()
+    private val userSessionPersistence = mockk<UserSessionPersistence>()
 
     @Before
     fun setup() {
         logoutUseCase = LogoutUseCase(
             authRepository = authRepository,
-            profileRepository = profileRepository
+            profileRepository = profileRepository,
+            userSessionPersistence = userSessionPersistence,
         )
 
         // Set up default behavior for mocks
         coEvery { profileRepository.delete() } returns Unit
         coEvery { authRepository.logout() } returns Unit
+        coEvery { userSessionPersistence.set(any()) } returns Unit
     }
 
     @Test
@@ -46,11 +51,13 @@ class LogoutUseCaseTest {
         // Then
         coVerify(exactly = 1) { profileRepository.delete() }
         coVerify(exactly = 1) { authRepository.logout() }
+        coVerify(exactly = 1) { userSessionPersistence.set(UserSession.LOGGED_OUT) }
 
         // Verify order of calls
         coVerifySequence {
             profileRepository.delete()
             authRepository.logout()
+            userSessionPersistence.set(UserSession.LOGGED_OUT)
         }
     }
 }


### PR DESCRIPTION
### Description

This PR introduced the `UserSessionPersistence` to keep full control of the user session state and be able to emit the actual logged in/out state when the app state is ready. 

Until now, we relied fully on the token storage, but this had a problem. We had to save it and perform certain operations after, but without navigating the user to the Home screen. This gives us the same reactive approach but with a full control over when the state changes. 

### Testing Steps

1. Test log in, log out flows. 
2. Test a fresh app open (after killing it) in each state to make sure the proper screen is shown at the start.
