### PR TITLE
Delete avatar

### DIFF
--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarEvent.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarEvent.kt
@@ -11,4 +11,6 @@ sealed class GravatarEvent {
     data object OnFailedAvatarDialogDismissed : GravatarEvent()
     data class OnFailedAvatarTapped(val uri: Uri) : GravatarEvent()
     data class OnDeleteAvatar(val avatarId: String) : GravatarEvent()
+    data class OnShowDeleteConfirmation(val avatarId: String) : GravatarEvent()
+    data object OnDismissDeleteConfirmation : GravatarEvent()
 }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarEvent.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarEvent.kt
@@ -10,4 +10,5 @@ sealed class GravatarEvent {
     data class OnFailedAvatarDismissed(val uri: Uri) : GravatarEvent()
     data object OnFailedAvatarDialogDismissed : GravatarEvent()
     data class OnFailedAvatarTapped(val uri: Uri) : GravatarEvent()
+    data class OnDeleteAvatar(val avatarId: String) : GravatarEvent()
 }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
@@ -40,6 +40,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import com.gravatar.app.homeUi.GravatarFileProvider
+import com.gravatar.app.homeUi.presentation.home.gravatar.components.AvatarDeletionConfirmationDialog
 import com.gravatar.app.homeUi.presentation.home.gravatar.components.AvatarOption
 import com.gravatar.app.homeUi.presentation.home.gravatar.components.FailedAvatarUploadAlertDialog
 import com.gravatar.app.homeUi.presentation.home.gravatar.components.GravatarHeader
@@ -145,6 +146,8 @@ internal fun GravatarScreen(
     onPickMediaClicked: () -> Unit,
     onEvent: (GravatarEvent) -> Unit = {},
 ) {
+    var confirmAvatarDeletion by rememberSaveable { mutableStateOf<String?>(null) }
+
     Surface(
         modifier = Modifier.fillMaxSize(),
     ) {
@@ -198,6 +201,9 @@ internal fun GravatarScreen(
                                     AvatarOption.Select -> {
                                         onEvent(GravatarEvent.OnAvatarSelected(avatar.imageId))
                                     }
+                                    AvatarOption.Delete -> {
+                                        confirmAvatarDeletion = avatar.imageId
+                                    }
                                 }
                             },
                             onFailedAvatarClicked = { uri ->
@@ -213,6 +219,15 @@ internal fun GravatarScreen(
                 onRetryClicked = { onEvent(GravatarEvent.OnImageCropped(it)) },
                 onDismiss = { onEvent(GravatarEvent.OnFailedAvatarDialogDismissed) },
             )
+            confirmAvatarDeletion?.let {
+                AvatarDeletionConfirmationDialog(
+                    onConfirm = {
+                        onEvent(GravatarEvent.OnDeleteAvatar(it))
+                        confirmAvatarDeletion = null
+                    },
+                    onDismiss = { confirmAvatarDeletion = null },
+                )
+            }
         }
     }
 }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
@@ -146,8 +146,6 @@ internal fun GravatarScreen(
     onPickMediaClicked: () -> Unit,
     onEvent: (GravatarEvent) -> Unit = {},
 ) {
-    var confirmAvatarDeletion by rememberSaveable { mutableStateOf<String?>(null) }
-
     Surface(
         modifier = Modifier.fillMaxSize(),
     ) {
@@ -201,8 +199,9 @@ internal fun GravatarScreen(
                                     AvatarOption.Select -> {
                                         onEvent(GravatarEvent.OnAvatarSelected(avatar.imageId))
                                     }
+
                                     AvatarOption.Delete -> {
-                                        confirmAvatarDeletion = avatar.imageId
+                                        onEvent(GravatarEvent.OnShowDeleteConfirmation(avatar.imageId))
                                     }
                                 }
                             },
@@ -219,13 +218,10 @@ internal fun GravatarScreen(
                 onRetryClicked = { onEvent(GravatarEvent.OnImageCropped(it)) },
                 onDismiss = { onEvent(GravatarEvent.OnFailedAvatarDialogDismissed) },
             )
-            confirmAvatarDeletion?.let {
+            uiState.confirmAvatarDeletionId?.let {
                 AvatarDeletionConfirmationDialog(
-                    onConfirm = {
-                        onEvent(GravatarEvent.OnDeleteAvatar(it))
-                        confirmAvatarDeletion = null
-                    },
-                    onDismiss = { confirmAvatarDeletion = null },
+                    onConfirm = { onEvent(GravatarEvent.OnDeleteAvatar(it)) },
+                    onDismiss = { onEvent(GravatarEvent.OnDismissDeleteConfirmation) },
                 )
             }
         }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarUiState.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarUiState.kt
@@ -13,6 +13,7 @@ internal data class GravatarUiState(
     val uploadingAvatar: Uri? = null,
     val failedUploads: List<AvatarUploadFailure> = emptyList(),
     val failedUploadDialog: AvatarUploadFailure? = null,
+    val confirmAvatarDeletionId: String? = null,
 ) {
     val avatarsUi: List<AvatarUi> = buildList {
         addAll(

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
@@ -1,6 +1,7 @@
 package com.gravatar.app.homeUi.presentation.home.gravatar
 
 import android.net.Uri
+import android.util.Log
 import androidx.core.net.toFile
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -49,6 +50,9 @@ internal class GravatarViewModel(
             GravatarEvent.OnFailedAvatarDialogDismissed -> dismissFailedUploadDialog()
             is GravatarEvent.OnFailedAvatarDismissed -> removedFailedUpload(event.uri)
             is GravatarEvent.OnFailedAvatarTapped -> showFailedUploadDialog(event.uri)
+            is GravatarEvent.OnDeleteAvatar -> {
+                Log.i("GravatarViewModel", "OnDeleteAvatar: ${event.avatarId}")
+            }
         }
     }
 

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
@@ -50,6 +50,8 @@ internal class GravatarViewModel(
             is GravatarEvent.OnFailedAvatarDismissed -> removedFailedUpload(event.uri)
             is GravatarEvent.OnFailedAvatarTapped -> showFailedUploadDialog(event.uri)
             is GravatarEvent.OnDeleteAvatar -> deleteAvatar(event.avatarId)
+            is GravatarEvent.OnShowDeleteConfirmation -> showDeleteConfirmation(event.avatarId)
+            GravatarEvent.OnDismissDeleteConfirmation -> dismissDeleteConfirmation()
         }
     }
 
@@ -71,6 +73,18 @@ internal class GravatarViewModel(
     private fun dismissFailedUploadDialog() {
         _uiState.update { currentState ->
             currentState.copy(failedUploadDialog = null)
+        }
+    }
+
+    private fun showDeleteConfirmation(avatarId: String) {
+        _uiState.update { currentState ->
+            currentState.copy(confirmAvatarDeletionId = avatarId)
+        }
+    }
+
+    private fun dismissDeleteConfirmation() {
+        _uiState.update { currentState ->
+            currentState.copy(confirmAvatarDeletionId = null)
         }
     }
 
@@ -210,6 +224,7 @@ internal class GravatarViewModel(
                         } else {
                             currentState.selectedAvatarId
                         },
+                        confirmAvatarDeletionId = null,
                     )
                 }
                 userRepository.deleteAvatar(avatarId)

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
@@ -208,7 +208,7 @@ internal class GravatarViewModel(
                         selectedAvatarId = if (isSelectedAvatar) {
                             null
                         } else {
-                            _uiState.value.selectedAvatarId
+                            currentState.selectedAvatarId
                         },
                     )
                 }
@@ -228,7 +228,7 @@ internal class GravatarViewModel(
                                 selectedAvatarId = if (isSelectedAvatar) {
                                     avatarId
                                 } else {
-                                    _uiState.value.selectedAvatarId
+                                    currentState.selectedAvatarId
                                 },
                             )
                         }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
@@ -1,7 +1,6 @@
 package com.gravatar.app.homeUi.presentation.home.gravatar
 
 import android.net.Uri
-import android.util.Log
 import androidx.core.net.toFile
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -50,9 +49,7 @@ internal class GravatarViewModel(
             GravatarEvent.OnFailedAvatarDialogDismissed -> dismissFailedUploadDialog()
             is GravatarEvent.OnFailedAvatarDismissed -> removedFailedUpload(event.uri)
             is GravatarEvent.OnFailedAvatarTapped -> showFailedUploadDialog(event.uri)
-            is GravatarEvent.OnDeleteAvatar -> {
-                Log.i("GravatarViewModel", "OnDeleteAvatar: ${event.avatarId}")
-            }
+            is GravatarEvent.OnDeleteAvatar -> deleteAvatar(event.avatarId)
         }
     }
 
@@ -197,4 +194,51 @@ internal class GravatarViewModel(
                 }
         }
     }
+
+    private fun deleteAvatar(avatarId: String) {
+        viewModelScope.launch {
+            val avatarIndex = _uiState.value.avatars.indexOfFirstOrNull { it.imageId == avatarId }
+            val isSelectedAvatar = avatarId == _uiState.value.selectedAvatarId
+            val avatar = avatarIndex?.let { _uiState.value.avatars[avatarIndex] }
+            if (avatar != null) {
+                _uiState.update { currentState ->
+                    val updatedAvatars = currentState.avatars.toMutableList().filter { it.imageId != avatarId }
+                    currentState.copy(
+                        avatars = updatedAvatars,
+                        selectedAvatarId = if (isSelectedAvatar) {
+                            null
+                        } else {
+                            _uiState.value.selectedAvatarId
+                        },
+                    )
+                }
+                userRepository.deleteAvatar(avatarId)
+                    .onSuccess { result ->
+                        // NOTIFY THE UI TO SHOW THE CONFIRMATION
+                    }
+                    .onFailure { error ->
+                        // NOTIFY THE UI TO SHOW AN ERROR
+
+                        _uiState.update { currentState ->
+                            val updatedAvatars = currentState.avatars.toMutableList().apply {
+                                add(avatarIndex, avatar)
+                            }
+                            currentState.copy(
+                                avatars = updatedAvatars,
+                                selectedAvatarId = if (isSelectedAvatar) {
+                                    avatarId
+                                } else {
+                                    _uiState.value.selectedAvatarId
+                                },
+                            )
+                        }
+                    }
+            }
+        }
+    }
+}
+
+private inline fun <T> List<T>.indexOfFirstOrNull(predicate: (T) -> Boolean): Int? {
+    val index = indexOfFirst { predicate(it) }
+    return if (index == -1) null else index
 }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/components/AvatarDeletionConfirmationDialog.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/components/AvatarDeletionConfirmationDialog.kt
@@ -1,0 +1,35 @@
+package com.gravatar.app.homeUi.presentation.home.gravatar.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.gravatar.app.homeUi.R
+
+@Composable
+internal fun AvatarDeletionConfirmationDialog(onConfirm: () -> Unit, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(text = stringResource(R.string.gravatar_tab_delete_confirmation_title))
+        },
+        text = {
+            Text(text = stringResource(R.string.gravatar_tab_delete_confirmation_message))
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(
+                    text = stringResource(R.string.gravatar_tab_delete_confirmation_confirm),
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(R.string.gravatar_tab_delete_confirmation_cancel))
+            }
+        },
+    )
+}

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/components/AvatarMoreOptionsPickerPopup.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/components/AvatarMoreOptionsPickerPopup.kt
@@ -41,10 +41,15 @@ internal fun AvatarMoreOptionsPickerPopup(
                     },
                 ),
                 PickerPopupItem(
-                    text = "Option 2",
-                    iconRes = null,
-                    contentDescription = "Option 2",
-                    onClick = { },
+                    text = stringResource(R.string.gravatar_tab_more_options_delete_avatar),
+                    iconRes = R.drawable.delete_icon,
+                    contentDescription = stringResource(
+                        R.string.gravatar_tab_more_options_delete_avatar_content_description
+                    ),
+                    contentColor = MaterialTheme.colorScheme.error,
+                    onClick = {
+                        onAvatarOptionClicked(AvatarOption.Delete)
+                    },
                 ),
             ),
         ),
@@ -53,6 +58,7 @@ internal fun AvatarMoreOptionsPickerPopup(
 
 internal sealed class AvatarOption {
     data object Select : AvatarOption()
+    data object Delete : AvatarOption()
 }
 
 @Preview

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/components/AvatarMoreOptionsPickerPopup.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/components/AvatarMoreOptionsPickerPopup.kt
@@ -7,9 +7,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import com.gravatar.app.homeUi.R
 import com.gravatar.app.homeUi.presentation.home.components.PickerPopup
 import com.gravatar.app.homeUi.presentation.home.components.PickerPopupItem
 import com.gravatar.app.homeUi.presentation.home.components.PickerPopupMenu
@@ -29,9 +31,11 @@ internal fun AvatarMoreOptionsPickerPopup(
         popupMenu = PickerPopupMenu(
             items = listOf(
                 PickerPopupItem(
-                    text = "Select",
-                    iconRes = null,
-                    contentDescription = "Select avatar",
+                    text = stringResource(R.string.gravatar_tab_more_options_make_current),
+                    iconRes = R.drawable.check_circle,
+                    contentDescription = stringResource(
+                        R.string.gravatar_tab_more_options_make_current_content_description
+                    ),
                     onClick = {
                         onAvatarOptionClicked(AvatarOption.Select)
                     },

--- a/homeUi/src/main/res/drawable/check_circle.xml
+++ b/homeUi/src/main/res/drawable/check_circle.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="m424,664 l282,-282 -56,-56 -226,226 -114,-114 -56,56 170,170ZM480,880q-83,0 -156,-31.5T197,763q-54,-54 -85.5,-127T80,480q0,-83 31.5,-156T197,197q54,-54 127,-85.5T480,80q83,0 156,31.5T763,197q54,54 85.5,127T880,480q0,83 -31.5,156T763,763q-54,54 -127,85.5T480,880ZM480,800q134,0 227,-93t93,-227q0,-134 -93,-227t-227,-93q-134,0 -227,93t-93,227q0,134 93,227t227,93ZM480,480Z"
+      android:fillColor="#e8eaed"/>
+</vector>

--- a/homeUi/src/main/res/drawable/delete_icon.xml
+++ b/homeUi/src/main/res/drawable/delete_icon.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M280,840q-33,0 -56.5,-23.5T200,760v-520h-40v-80h200v-40h240v40h200v80h-40v520q0,33 -23.5,56.5T680,840L280,840ZM680,240L280,240v520h400v-520ZM360,680h80v-360h-80v360ZM520,680h80v-360h-80v360ZM280,240v520,-520Z"
+      android:fillColor="#e8eaed"/>
+</vector>

--- a/homeUi/src/main/res/values/strings.xml
+++ b/homeUi/src/main/res/values/strings.xml
@@ -35,4 +35,10 @@
     <string name="gravatar_tab_avatar_upload_failure_dialog_remove_upload">Remove upload</string>
     <string name="gravatar_tab_more_options_make_current">Make current</string>
     <string name="gravatar_tab_more_options_make_current_content_description">Select avatar as current one</string>
+    <string name="gravatar_tab_more_options_delete_avatar">Delete</string>
+    <string name="gravatar_tab_more_options_delete_avatar_content_description">Delete this avatar</string>
+    <string name="gravatar_tab_delete_confirmation_title">Delete Image</string>
+    <string name="gravatar_tab_delete_confirmation_message">Are you sure you want to delete this image?</string>
+    <string name="gravatar_tab_delete_confirmation_confirm">Delete</string>
+    <string name="gravatar_tab_delete_confirmation_cancel">Cancel</string>
 </resources>

--- a/homeUi/src/main/res/values/strings.xml
+++ b/homeUi/src/main/res/values/strings.xml
@@ -33,4 +33,6 @@
     <string name="gravatar_tab_avatar_upload_failure_image_too_big">The provided image exceeds the maximum size: 10MB</string>
     <string name="gravatar_tab_avatar_upload_error_action">Retry</string>
     <string name="gravatar_tab_avatar_upload_failure_dialog_remove_upload">Remove upload</string>
+    <string name="gravatar_tab_more_options_make_current">Make current</string>
+    <string name="gravatar_tab_more_options_make_current_content_description">Select avatar as current one</string>
 </resources>

--- a/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
+++ b/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
@@ -475,6 +475,122 @@ class GravatarViewModelTest {
         }
     }
 
+    @Test
+    fun `onEvent OnDeleteAvatar should delete non-selected avatar successfully`() = runTest {
+        // Given
+        val avatars = createAvatars()
+        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        initViewModel()
+        advanceUntilIdle()
+
+        val avatarIdToDelete = "2"
+        coEvery { userRepository.deleteAvatar(avatarIdToDelete) } returns Result.success(Unit)
+
+        // When
+        viewModel.onEvent(GravatarEvent.OnDeleteAvatar(avatarIdToDelete))
+        advanceUntilIdle()
+
+        // Then
+        viewModel.uiState.test {
+            val expectedState = GravatarUiState(
+                isLoading = false,
+                avatars = avatars.filter { it.imageId != avatarIdToDelete }
+            )
+            assertEquals(expectedState, awaitItem())
+        }
+        coVerify { userRepository.deleteAvatar(avatarIdToDelete) }
+    }
+
+    @Test
+    fun `onEvent OnDeleteAvatar should delete selected avatar successfully and update selectedAvatarId`() = runTest {
+        // Given
+        val avatars = createAvatars()
+        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        initViewModel()
+        advanceUntilIdle()
+
+        // Select an avatar first
+        val selectedAvatarId = "1"
+        coEvery { userRepository.selectAvatar(selectedAvatarId) } returns Result.success(Unit)
+        viewModel.onEvent(GravatarEvent.OnAvatarSelected(selectedAvatarId))
+        advanceUntilIdle()
+
+        // When
+        coEvery { userRepository.deleteAvatar(selectedAvatarId) } returns Result.success(Unit)
+        viewModel.onEvent(GravatarEvent.OnDeleteAvatar(selectedAvatarId))
+        advanceUntilIdle()
+
+        // Then
+        viewModel.uiState.test {
+            val expectedState = GravatarUiState(
+                isLoading = false,
+                avatars = avatars.filter { it.imageId != selectedAvatarId },
+                selectedAvatarId = null
+            )
+            assertEquals(expectedState, awaitItem())
+        }
+        coVerify { userRepository.deleteAvatar(selectedAvatarId) }
+    }
+
+    @Test
+    fun `onEvent OnDeleteAvatar should handle failure and restore avatar`() = runTest {
+        // Given
+        val avatars = createAvatars()
+        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        initViewModel()
+        advanceUntilIdle()
+
+        val avatarIdToDelete = "2"
+        coEvery { userRepository.deleteAvatar(avatarIdToDelete) } returns Result.failure(RuntimeException("Test exception"))
+
+        // When
+        viewModel.onEvent(GravatarEvent.OnDeleteAvatar(avatarIdToDelete))
+        advanceUntilIdle()
+
+        // Then
+        viewModel.uiState.test {
+            // The state should be unchanged since the avatar should be restored after failure
+            val expectedState = GravatarUiState(
+                isLoading = false,
+                avatars = avatars
+            )
+            assertEquals(expectedState, awaitItem())
+        }
+        coVerify { userRepository.deleteAvatar(avatarIdToDelete) }
+    }
+
+    @Test
+    fun `onEvent OnDeleteAvatar should handle failure and restore selected avatar`() = runTest {
+        // Given
+        val avatars = createAvatars()
+        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        initViewModel()
+        advanceUntilIdle()
+
+        // Select an avatar first
+        val selectedAvatarId = "1"
+        coEvery { userRepository.selectAvatar(selectedAvatarId) } returns Result.success(Unit)
+        viewModel.onEvent(GravatarEvent.OnAvatarSelected(selectedAvatarId))
+        advanceUntilIdle()
+
+        // When
+        coEvery { userRepository.deleteAvatar(selectedAvatarId) } returns Result.failure(RuntimeException("Test exception"))
+        viewModel.onEvent(GravatarEvent.OnDeleteAvatar(selectedAvatarId))
+        advanceUntilIdle()
+
+        // Then
+        viewModel.uiState.test {
+            // The state should be unchanged since the avatar should be restored after failure
+            val expectedState = GravatarUiState(
+                isLoading = false,
+                avatars = avatars,
+                selectedAvatarId = selectedAvatarId
+            )
+            assertEquals(expectedState, awaitItem())
+        }
+        coVerify { userRepository.deleteAvatar(selectedAvatarId) }
+    }
+
     private fun initViewModel() {
         viewModel = GravatarViewModel(
             userRepository = userRepository,

--- a/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
+++ b/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
@@ -515,6 +515,10 @@ class GravatarViewModelTest {
         viewModel.onEvent(GravatarEvent.OnAvatarSelected(selectedAvatarId))
         advanceUntilIdle()
 
+        // Show delete confirmation
+        viewModel.onEvent(GravatarEvent.OnShowDeleteConfirmation(selectedAvatarId))
+        advanceUntilIdle()
+
         // When
         coEvery { userRepository.deleteAvatar(selectedAvatarId) } returns Result.success(Unit)
         viewModel.onEvent(GravatarEvent.OnDeleteAvatar(selectedAvatarId))
@@ -589,6 +593,58 @@ class GravatarViewModelTest {
             assertEquals(expectedState, awaitItem())
         }
         coVerify { userRepository.deleteAvatar(selectedAvatarId) }
+    }
+
+    @Test
+    fun `onEvent OnShowDeleteConfirmation should update confirmAvatarDeletionId`() = runTest {
+        // Given
+        val avatars = createAvatars()
+        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        initViewModel()
+        advanceUntilIdle()
+
+        val avatarIdToDelete = "2"
+
+        // When
+        viewModel.onEvent(GravatarEvent.OnShowDeleteConfirmation(avatarIdToDelete))
+        advanceUntilIdle()
+
+        // Then
+        viewModel.uiState.test {
+            val expectedState = GravatarUiState(
+                isLoading = false,
+                avatars = avatars,
+                confirmAvatarDeletionId = avatarIdToDelete
+            )
+            assertEquals(expectedState, awaitItem())
+        }
+    }
+
+    @Test
+    fun `onEvent OnDismissDeleteConfirmation should clear confirmAvatarDeletionId`() = runTest {
+        // Given
+        val avatars = createAvatars()
+        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        initViewModel()
+        advanceUntilIdle()
+
+        val avatarIdToDelete = "2"
+        viewModel.onEvent(GravatarEvent.OnShowDeleteConfirmation(avatarIdToDelete))
+        advanceUntilIdle()
+
+        // When
+        viewModel.onEvent(GravatarEvent.OnDismissDeleteConfirmation)
+        advanceUntilIdle()
+
+        // Then
+        viewModel.uiState.test {
+            val expectedState = GravatarUiState(
+                isLoading = false,
+                avatars = avatars,
+                confirmAvatarDeletionId = null
+            )
+            assertEquals(expectedState, awaitItem())
+        }
     }
 
     private fun initViewModel() {

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/RealUserRepository.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/RealUserRepository.kt
@@ -86,4 +86,21 @@ internal class RealUserRepository(
             GravatarResult.Failure(ErrorType.Unauthorized)
         }
     }
+
+    override suspend fun deleteAvatar(avatarId: String): Result<Unit> {
+        val token = tokenStorage.get().firstOrNull()
+        return if (token != null) {
+            when (val result = avatarService.deleteAvatarCatching(avatarId, token)) {
+                is GravatarResult.Success -> {
+                    Result.success(Unit)
+                }
+
+                is GravatarResult.Failure -> {
+                    Result.failure(IllegalStateException("Failed to delete avatar: ${result.error}"))
+                }
+            }
+        } else {
+            Result.failure(IllegalStateException("User is not logged in"))
+        }
+    }
 }

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/repository/UserRepository.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/repository/UserRepository.kt
@@ -18,4 +18,6 @@ interface UserRepository {
     suspend fun updateProfile(updateRequest: UpdateProfileRequest): Result<Profile>
 
     suspend fun uploadAvatar(avatarFile: File): GravatarResult<Avatar, ErrorType>
+
+    suspend fun deleteAvatar(avatarId: String): Result<Unit>
 }

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/RealUserRepositoryTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/RealUserRepositoryTest.kt
@@ -420,6 +420,93 @@ class RealUserRepositoryTest {
         }
     }
 
+    @Test
+    fun `deleteAvatar should return success when user is logged in and service returns success`() = runTest {
+        // Given
+        val avatarId = "test-avatar-id"
+
+        // Save token
+        tokenStorage.save(testToken)
+
+        // Mock avatar service
+        val avatarResult = GravatarResult.Success<Unit, ErrorType>(Unit)
+        coEvery {
+            avatarService.deleteAvatarCatching(
+                avatarId = avatarId,
+                oauthToken = testToken
+            )
+        } returns avatarResult
+
+        // When
+        val result = repository.deleteAvatar(avatarId)
+
+        // Then
+        assertTrue(result.isSuccess)
+
+        // Verify interactions
+        coVerify {
+            avatarService.deleteAvatarCatching(
+                avatarId = avatarId,
+                oauthToken = testToken
+            )
+        }
+    }
+
+    @Test
+    fun `deleteAvatar should return failure when user is not logged in`() = runTest {
+        // Given
+        val avatarId = "test-avatar-id"
+        tokenStorage.clear()
+
+        // When
+        val result = repository.deleteAvatar(avatarId)
+
+        // Then
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is IllegalStateException)
+        assertEquals("User is not logged in", exception?.message)
+
+        // Verify no interactions with services
+        coVerify(exactly = 0) { avatarService.deleteAvatarCatching(any(), any()) }
+    }
+
+    @Test
+    fun `deleteAvatar should return failure when avatar service returns failure`() = runTest {
+        // Given
+        val avatarId = "test-avatar-id"
+
+        // Save token
+        tokenStorage.save(testToken)
+
+        // Mock avatar service to return a failure
+        val errorType = ErrorType.Server
+        val avatarResult = GravatarResult.Failure<Unit, ErrorType>(errorType)
+        coEvery {
+            avatarService.deleteAvatarCatching(
+                avatarId = avatarId,
+                oauthToken = testToken
+            )
+        } returns avatarResult
+
+        // When
+        val result = repository.deleteAvatar(avatarId)
+
+        // Then
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is IllegalStateException)
+        assertEquals("Failed to delete avatar: $errorType", exception?.message)
+
+        // Verify interactions
+        coVerify {
+            avatarService.deleteAvatarCatching(
+                avatarId = avatarId,
+                oauthToken = testToken
+            )
+        }
+    }
+
     private fun createTestProfile(): Profile {
         return Profile {
             hash = testHash


### PR DESCRIPTION
### Description

This PR adds the **Delete** option for avatars. 

https://github.com/user-attachments/assets/fd2954f2-3242-4a85-a553-bcc2da0f84f5

Notes:

- This PR doesn't provide additional confirmation when the avatar is properly deleted beyond removing it from the list. We'll probably need to add a Toast
- The same occurs when an error occurs.

### Testing Steps

- Launch the app
- With an avatar already selected, try to delete it
- Verify you can delete the selected avatar as expected.
- Verify that you can delete a non-selected avatar
- Verify that if an error happens while deleting the avatar, the avatar is re-added to the list. (You can test that by blocking the delete avatar, overriding the backend response, or disabling the network on the device).
