### PR TITLE
Download avatar

### DIFF
--- a/homeUi/src/main/AndroidManifest.xml
+++ b/homeUi/src/main/AndroidManifest.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
+
     <application>
         <provider
             android:name=".GravatarFileProvider"

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/ImageDownloader.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/ImageDownloader.kt
@@ -1,0 +1,74 @@
+package com.gravatar.app.homeUi
+
+import android.app.DownloadManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Environment
+import com.gravatar.BuildConfig
+import com.gravatar.services.GravatarResult
+import java.net.URI
+
+internal class ImageDownloader(
+    private val context: Context,
+) {
+    private val downloadManager: DownloadManager? = context.getSystemService(DownloadManager::class.java)
+    private val appName: String by lazy { context.appName }
+
+    fun downloadImage(imageUrl: URI): GravatarResult<Unit, DownloadManagerError> {
+        return when {
+            downloadManager == null -> GravatarResult.Failure(DownloadManagerError.DOWNLOAD_MANAGER_NOT_AVAILABLE)
+            !isDownloadManagerEnabled() -> GravatarResult.Failure(DownloadManagerError.DOWNLOAD_MANAGER_DISABLED)
+            else -> {
+                val request = DownloadManager.Request(Uri.parse(imageUrl.withMaxSizeQueryParam().toString()))
+                    .addRequestHeader("X-Platform", "Android")
+                    .addRequestHeader("X-SDK-Version", BuildConfig.SDK_VERSION)
+                    .addRequestHeader("X-Source", appName)
+                    .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+                    .setMimeType("image/*")
+                    .setDestinationInExternalPublicDir(
+                        Environment.DIRECTORY_DOWNLOADS,
+                        "gravatar_image_${System.currentTimeMillis()}.png",
+                    )
+                downloadManager.enqueue(request)
+                GravatarResult.Success(Unit)
+            }
+        }
+    }
+
+    private fun isDownloadManagerEnabled(): Boolean {
+        val downloadManagerPackageName = "com.android.providers.downloads"
+        val state: Int = context.packageManager.getApplicationEnabledSetting(downloadManagerPackageName)
+
+        return !(
+            state == PackageManager.COMPONENT_ENABLED_STATE_DISABLED ||
+                state == PackageManager.COMPONENT_ENABLED_STATE_DISABLED_USER
+            )
+    }
+
+    private fun URI.withMaxSizeQueryParam(): URI {
+        return URI(
+            scheme,
+            userInfo,
+            host,
+            port,
+            path,
+            "size=max",
+            fragment,
+        )
+    }
+}
+
+internal enum class DownloadManagerError {
+    DOWNLOAD_MANAGER_NOT_AVAILABLE,
+    DOWNLOAD_MANAGER_DISABLED,
+}
+
+internal val Context.appName: String
+    get() {
+        val applicationInfo = packageManager.getApplicationInfo(
+            packageName,
+            PackageManager.GET_META_DATA,
+        )
+        return packageManager.getApplicationLabel(applicationInfo).toString()
+    }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/di/HomeUiModule.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/di/HomeUiModule.kt
@@ -1,16 +1,19 @@
 package com.gravatar.app.homeUi.di
 
+import com.gravatar.app.homeUi.ImageDownloader
 import com.gravatar.app.homeUi.presentation.FileUtils
 import com.gravatar.app.homeUi.presentation.home.gravatar.GravatarViewModel
 import com.gravatar.app.homeUi.presentation.home.profile.ProfileViewModel
 import com.gravatar.app.usercomponent.di.userComponentModule
 import com.gravatar.services.ProfileService
+import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
 val homeUiModule = module {
     single { ProfileService() }
+    factory<ImageDownloader> { ImageDownloader(androidContext()) }
     factoryOf(::FileUtils)
     viewModelOf(::ProfileViewModel)
     viewModelOf(::GravatarViewModel)

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/PermissionUtils.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/PermissionUtils.kt
@@ -1,0 +1,46 @@
+package com.gravatar.app.homeUi.presentation
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.provider.Settings
+import androidx.activity.ComponentActivity
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+
+internal fun Context.openAppPermissionSettings() {
+    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+    val uri = Uri.fromParts("package", packageName, null)
+    intent.setData(uri)
+    startActivity(intent)
+}
+
+internal fun Context.withPermission(
+    permission: String,
+    onRequestPermission: (String) -> Unit,
+    onShowRationale: () -> Unit = {},
+    grantedCallback: () -> Unit,
+) {
+    val activity = findComponentActivity()
+    when {
+        ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED -> {
+            grantedCallback()
+        }
+
+        activity != null && ActivityCompat.shouldShowRequestPermissionRationale(activity, permission) -> {
+            onShowRationale()
+        }
+
+        else -> {
+            onRequestPermission(permission)
+        }
+    }
+}
+
+internal fun Context.findComponentActivity(): ComponentActivity? = when (this) {
+    is ComponentActivity -> this
+    is ContextWrapper -> baseContext.findComponentActivity()
+    else -> null
+}

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/components/PermissionRationaleDialog.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/components/PermissionRationaleDialog.kt
@@ -40,7 +40,7 @@ internal fun PermissionRationaleDialog(
                         onConfirmation()
                     },
                 ) {
-                    Text(stringResource(R.string.permission_required_rationale_message))
+                    Text(stringResource(R.string.permission_required_open_settings))
                 }
             },
         )

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/components/PermissionRationaleDialog.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/components/PermissionRationaleDialog.kt
@@ -1,0 +1,48 @@
+package com.gravatar.app.homeUi.presentation.home.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.gravatar.app.homeUi.R
+
+@Composable
+internal fun PermissionRationaleDialog(
+    isVisible: Boolean,
+    message: String,
+    onConfirmation: () -> Unit,
+    onDismiss: () -> Unit = {},
+) {
+    if (isVisible) {
+        AlertDialog(
+            title = {
+                Text(text = stringResource(R.string.permission_required_alert_title))
+            },
+            text = {
+                Text(
+                    text = message,
+                )
+            },
+            onDismissRequest = onDismiss,
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        onDismiss()
+                    },
+                ) {
+                    Text(stringResource(R.string.permission_required_dismiss))
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        onConfirmation()
+                    },
+                ) {
+                    Text(stringResource(R.string.permission_required_rationale_message))
+                }
+            },
+        )
+    }
+}

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarEvent.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarEvent.kt
@@ -11,6 +11,7 @@ sealed class GravatarEvent {
     data object OnFailedAvatarDialogDismissed : GravatarEvent()
     data class OnFailedAvatarTapped(val uri: Uri) : GravatarEvent()
     data class OnDeleteAvatar(val avatarId: String) : GravatarEvent()
+    data class OnDownloadAvatar(val avatarId: String) : GravatarEvent()
     data class OnShowDeleteConfirmation(val avatarId: String) : GravatarEvent()
     data object OnDismissDeleteConfirmation : GravatarEvent()
 }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
@@ -1,5 +1,6 @@
 package com.gravatar.app.homeUi.presentation.home.gravatar
 
+import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.graphics.Color
@@ -28,18 +29,22 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import com.gravatar.app.homeUi.GravatarFileProvider
+import com.gravatar.app.homeUi.R
+import com.gravatar.app.homeUi.presentation.home.components.PermissionRationaleDialog
 import com.gravatar.app.homeUi.presentation.home.gravatar.components.AvatarDeletionConfirmationDialog
 import com.gravatar.app.homeUi.presentation.home.gravatar.components.AvatarOption
 import com.gravatar.app.homeUi.presentation.home.gravatar.components.FailedAvatarUploadAlertDialog
@@ -47,6 +52,8 @@ import com.gravatar.app.homeUi.presentation.home.gravatar.components.GravatarHea
 import com.gravatar.app.homeUi.presentation.home.gravatar.components.UploadNewAvatarSection
 import com.gravatar.app.homeUi.presentation.home.gravatar.components.avatarSize
 import com.gravatar.app.homeUi.presentation.home.gravatar.components.avatarsGridSection
+import com.gravatar.app.homeUi.presentation.openAppPermissionSettings
+import com.gravatar.app.homeUi.presentation.withPermission
 import com.gravatar.app.usercomponent.domain.usecase.Logout
 import com.gravatar.restapi.models.Avatar
 import com.yalantis.ucrop.UCrop
@@ -146,6 +153,39 @@ internal fun GravatarScreen(
     onPickMediaClicked: () -> Unit,
     onEvent: (GravatarEvent) -> Unit = {},
 ) {
+    val context = LocalContext.current
+    var storagePermissionRationaleDialogVisible by rememberSaveable { mutableStateOf(false) }
+    var avatarToDownload: Avatar? by remember { mutableStateOf(null) }
+
+    val writeExternalStoragePermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { isGranted: Boolean ->
+        if (isGranted) {
+            avatarToDownload?.let { onEvent(GravatarEvent.OnDownloadAvatar(it.imageId)) }
+        } else {
+            storagePermissionRationaleDialogVisible = true
+        }
+        avatarToDownload = null
+    }
+
+    val permissionAwareDownloadImageCallback: (Avatar) -> Unit = { avatar ->
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.Q) {
+            context.withPermission(
+                permission = Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                onRequestPermission = {
+                    avatarToDownload = avatar
+                    writeExternalStoragePermissionLauncher.launch(it)
+                },
+                onShowRationale = { storagePermissionRationaleDialogVisible = true },
+                grantedCallback = {
+                    onEvent(GravatarEvent.OnDownloadAvatar(avatar.imageId))
+                },
+            )
+        } else {
+            onEvent(GravatarEvent.OnDownloadAvatar(avatar.imageId))
+        }
+    }
+
     Surface(
         modifier = Modifier.fillMaxSize(),
     ) {
@@ -205,7 +245,7 @@ internal fun GravatarScreen(
                                     }
 
                                     AvatarOption.Download -> {
-                                        onEvent(GravatarEvent.OnDownloadAvatar(avatar.imageId))
+                                        permissionAwareDownloadImageCallback(avatar)
                                     }
                                 }
                             },
@@ -221,6 +261,15 @@ internal fun GravatarScreen(
                 onRemoveUploadClicked = { onEvent(GravatarEvent.OnFailedAvatarDismissed(it)) },
                 onRetryClicked = { onEvent(GravatarEvent.OnImageCropped(it)) },
                 onDismiss = { onEvent(GravatarEvent.OnFailedAvatarDialogDismissed) },
+            )
+            PermissionRationaleDialog(
+                isVisible = storagePermissionRationaleDialogVisible,
+                message = stringResource(R.string.permission_required_write_external_storage_rationale_message),
+                onConfirmation = {
+                    storagePermissionRationaleDialogVisible = false
+                    context.openAppPermissionSettings()
+                },
+                onDismiss = { storagePermissionRationaleDialogVisible = false },
             )
             uiState.confirmAvatarDeletionId?.let {
                 AvatarDeletionConfirmationDialog(

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
@@ -203,6 +203,10 @@ internal fun GravatarScreen(
                                     AvatarOption.Delete -> {
                                         onEvent(GravatarEvent.OnShowDeleteConfirmation(avatar.imageId))
                                     }
+
+                                    AvatarOption.Download -> {
+                                        onEvent(GravatarEvent.OnDownloadAvatar(avatar.imageId))
+                                    }
                                 }
                             },
                             onFailedAvatarClicked = { uri ->

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
@@ -59,6 +59,7 @@ internal class GravatarViewModel(
             is GravatarEvent.OnFailedAvatarDismissed -> removedFailedUpload(event.uri)
             is GravatarEvent.OnFailedAvatarTapped -> showFailedUploadDialog(event.uri)
             is GravatarEvent.OnDeleteAvatar -> deleteAvatar(event.avatarId)
+            is GravatarEvent.OnDownloadAvatar -> { /* No implementation yet */ }
             is GravatarEvent.OnShowDeleteConfirmation -> showDeleteConfirmation(event.avatarId)
             GravatarEvent.OnDismissDeleteConfirmation -> dismissDeleteConfirmation()
         }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
@@ -4,6 +4,8 @@ import android.net.Uri
 import androidx.core.net.toFile
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.gravatar.app.homeUi.DownloadManagerError
+import com.gravatar.app.homeUi.ImageDownloader
 import com.gravatar.app.homeUi.presentation.FileUtils
 import com.gravatar.app.usercomponent.domain.repository.UserRepository
 import com.gravatar.app.usercomponent.domain.usecase.DeleteUserAvatar
@@ -27,6 +29,7 @@ internal class GravatarViewModel(
     private val deleteUserAvatar: DeleteUserAvatar,
     private val userRepository: UserRepository,
     private val fileUtils: FileUtils,
+    private val imageDownloader: ImageDownloader,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(GravatarUiState())
@@ -59,7 +62,7 @@ internal class GravatarViewModel(
             is GravatarEvent.OnFailedAvatarDismissed -> removedFailedUpload(event.uri)
             is GravatarEvent.OnFailedAvatarTapped -> showFailedUploadDialog(event.uri)
             is GravatarEvent.OnDeleteAvatar -> deleteAvatar(event.avatarId)
-            is GravatarEvent.OnDownloadAvatar -> { /* No implementation yet */ }
+            is GravatarEvent.OnDownloadAvatar -> downloadAvatar(event.avatarId)
             is GravatarEvent.OnShowDeleteConfirmation -> showDeleteConfirmation(event.avatarId)
             GravatarEvent.OnDismissDeleteConfirmation -> dismissDeleteConfirmation()
         }
@@ -270,6 +273,30 @@ internal class GravatarViewModel(
                 }
             }
             .launchIn(viewModelScope)
+    }
+
+    private fun downloadAvatar(avatarId: String) {
+        viewModelScope.launch {
+            _uiState.value.avatars.firstOrNull { it.imageId == avatarId }?.imageUrl?.let { url ->
+                when (val result = imageDownloader.downloadImage(url)) {
+                    is GravatarResult.Failure -> {
+                        when (result.error) {
+                            DownloadManagerError.DOWNLOAD_MANAGER_NOT_AVAILABLE -> {
+                                // Notify the UI that the download manager is not available - We should update tests to handle this case
+                            }
+
+                            DownloadManagerError.DOWNLOAD_MANAGER_DISABLED -> {
+                                // Notify the UI that the download manager is disabled - We should update tests to handle this case
+                            }
+                        }
+                    }
+
+                    is GravatarResult.Success -> {
+                        // Notify the UI in order to show a confirmation - We should update tests to handle this case
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/components/AvatarMoreOptionsPickerPopup.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/components/AvatarMoreOptionsPickerPopup.kt
@@ -41,6 +41,16 @@ internal fun AvatarMoreOptionsPickerPopup(
                     },
                 ),
                 PickerPopupItem(
+                    text = stringResource(R.string.gravatar_tab_more_options_download_avatar),
+                    iconRes = R.drawable.gravatar_more_options_download,
+                    contentDescription = stringResource(
+                        R.string.gravatar_tab_more_options_download_avatar_content_description
+                    ),
+                    onClick = {
+                        onAvatarOptionClicked(AvatarOption.Download)
+                    },
+                ),
+                PickerPopupItem(
                     text = stringResource(R.string.gravatar_tab_more_options_delete_avatar),
                     iconRes = R.drawable.delete_icon,
                     contentDescription = stringResource(
@@ -59,6 +69,7 @@ internal fun AvatarMoreOptionsPickerPopup(
 internal sealed class AvatarOption {
     data object Select : AvatarOption()
     data object Delete : AvatarOption()
+    data object Download : AvatarOption()
 }
 
 @Preview

--- a/homeUi/src/main/res/drawable/gravatar_more_options_download.xml
+++ b/homeUi/src/main/res/drawable/gravatar_more_options_download.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M18,11.3L17,10.2L13,14.2V3H11.5V14.3L7,10.2L6,11.3L12.2,17.1L18,11.3ZM18.5,15V18.5H5.5V15H4V20H20V15H18.5Z"
+      android:fillColor="#101517"/>
+</vector>

--- a/homeUi/src/main/res/values/strings.xml
+++ b/homeUi/src/main/res/values/strings.xml
@@ -43,4 +43,8 @@
     <string name="gravatar_tab_delete_confirmation_message">Are you sure you want to delete this image?</string>
     <string name="gravatar_tab_delete_confirmation_confirm">Delete</string>
     <string name="gravatar_tab_delete_confirmation_cancel">Cancel</string>
+    <string name="permission_required_alert_title">Permission required</string>
+    <string name="permission_required_rationale_message">To take a picture, you need to grant camera permission. You can grant it in the app settings.</string>
+    <string name="permission_required_dismiss">Dismiss</string>
+    <string name="permission_required_write_external_storage_rationale_message">To save the image in a public folder, you need to grant permission. You can grant it in the app settings.</string>
 </resources>

--- a/homeUi/src/main/res/values/strings.xml
+++ b/homeUi/src/main/res/values/strings.xml
@@ -44,7 +44,7 @@
     <string name="gravatar_tab_delete_confirmation_confirm">Delete</string>
     <string name="gravatar_tab_delete_confirmation_cancel">Cancel</string>
     <string name="permission_required_alert_title">Permission required</string>
-    <string name="permission_required_rationale_message">To take a picture, you need to grant camera permission. You can grant it in the app settings.</string>
+    <string name="permission_required_open_settings">Open settings</string>
     <string name="permission_required_dismiss">Dismiss</string>
     <string name="permission_required_write_external_storage_rationale_message">To save the image in a public folder, you need to grant permission. You can grant it in the app settings.</string>
 </resources>

--- a/homeUi/src/main/res/values/strings.xml
+++ b/homeUi/src/main/res/values/strings.xml
@@ -37,6 +37,8 @@
     <string name="gravatar_tab_more_options_make_current_content_description">Select avatar as current one</string>
     <string name="gravatar_tab_more_options_delete_avatar">Delete</string>
     <string name="gravatar_tab_more_options_delete_avatar_content_description">Delete this avatar</string>
+    <string name="gravatar_tab_more_options_download_avatar">Download Image</string>
+    <string name="gravatar_tab_more_options_download_avatar_content_description">Download Image</string>
     <string name="gravatar_tab_delete_confirmation_title">Delete Image</string>
     <string name="gravatar_tab_delete_confirmation_message">Are you sure you want to delete this image?</string>
     <string name="gravatar_tab_delete_confirmation_confirm">Delete</string>

--- a/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
+++ b/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.core.net.toFile
 import app.cash.turbine.test
 import com.gravatar.AvatarUrl
+import com.gravatar.app.homeUi.ImageDownloader
 import com.gravatar.app.homeUi.presentation.FileUtils
 import com.gravatar.app.testUtils.CoroutineTestRule
 import com.gravatar.app.usercomponent.domain.repository.UserRepository
@@ -47,6 +48,7 @@ class GravatarViewModelTest {
     private val selectUserAvatar: SelectUserAvatar = mockk()
     private val deleteUserAvatar: DeleteUserAvatar = mockk()
     private val fileUtils: FileUtils = mockk()
+    private val imageDownloader: ImageDownloader = mockk()
     private lateinit var viewModel: GravatarViewModel
 
     private val avatarUrlFlow: MutableSharedFlow<URL?> = MutableSharedFlow()
@@ -678,6 +680,70 @@ class GravatarViewModelTest {
         }
     }
 
+    @Test
+    fun `onEvent OnDownloadAvatar should download avatar image`() = runTest {
+        // Given
+        val avatars = createAvatars()
+        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        initViewModel()
+        advanceUntilIdle()
+
+        val avatarId = "1"
+        val avatarUrl = avatars.first { it.imageId == avatarId }.imageUrl
+        coEvery { imageDownloader.downloadImage(avatarUrl) } returns GravatarResult.Success(Unit)
+
+        // When
+        viewModel.onEvent(GravatarEvent.OnDownloadAvatar(avatarId))
+        advanceUntilIdle()
+
+        // Then
+        coVerify { imageDownloader.downloadImage(avatarUrl) }
+    }
+
+    @Test
+    fun `onEvent OnDownloadAvatar should handle download manager not available`() = runTest {
+        // Given
+        val avatars = createAvatars()
+        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        initViewModel()
+        advanceUntilIdle()
+
+        val avatarId = "1"
+        val avatarUrl = avatars.first { it.imageId == avatarId }.imageUrl
+        coEvery {
+            imageDownloader.downloadImage(avatarUrl)
+        } returns GravatarResult.Failure(com.gravatar.app.homeUi.DownloadManagerError.DOWNLOAD_MANAGER_NOT_AVAILABLE)
+
+        // When
+        viewModel.onEvent(GravatarEvent.OnDownloadAvatar(avatarId))
+        advanceUntilIdle()
+
+        // Then
+        coVerify { imageDownloader.downloadImage(avatarUrl) }
+    }
+
+    @Test
+    fun `onEvent OnDownloadAvatar should handle download manager disabled`() = runTest {
+        // Given
+        val avatars = createAvatars()
+        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        initViewModel()
+        advanceUntilIdle()
+
+        val avatarId = "1"
+        val avatarUrl = avatars.first { it.imageId == avatarId }.imageUrl
+        coEvery {
+            imageDownloader.downloadImage(avatarUrl)
+        } returns GravatarResult.Failure(com.gravatar.app.homeUi.DownloadManagerError.DOWNLOAD_MANAGER_DISABLED)
+
+        // When
+        viewModel.onEvent(GravatarEvent.OnDownloadAvatar(avatarId))
+        advanceUntilIdle()
+
+        // Then
+        coVerify { imageDownloader.downloadImage(avatarUrl) }
+    }
+
     private fun initViewModel() {
         viewModel = GravatarViewModel(
             getAvatarUrl = getAvatarUrl,
@@ -685,6 +751,7 @@ class GravatarViewModelTest {
             userRepository = userRepository,
             fileUtils = fileUtils,
             deleteUserAvatar = deleteUserAvatar,
+            imageDownloader = imageDownloader,
         )
     }
 


### PR DESCRIPTION
### Description

This PR adds the option to download the avatars. It uses the DownloadManager as we did in the SDK.

When the device API is < 29, the app should check and ask for permission to write to the external storage.

**Note:** Error handling is not implemented in this PR. We need to notify the UI through the ViewModel about the different errors and inform the user.

**API < 29 (In this case 28)**

https://github.com/user-attachments/assets/f21647dd-086a-468f-b756-17fa61aaf780

### Testing Steps

Please test the PR on a device with API < 29 and on a device with API >= 29.

**API < 29**
- Verify that the first time you try to download an avatar, you are asked for permission.
- Play with that flow: Deny the permission, verify the following dialog, and accept the permission. Verify that you are redirected to the app settings...
- Verify the avatar is finally downloaded to the device

**API >= 29**
- Verify the download flow works as expected.
