### PR TITLE
Observe profile via Flow

### DIFF
--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileEvent.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileEvent.kt
@@ -8,4 +8,6 @@ internal sealed class ProfileEvent {
     ) : ProfileEvent()
 
     object OnSaveClicked : ProfileEvent()
+
+    object OnRefreshProfile : ProfileEvent()
 }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileScreen.kt
@@ -43,7 +43,7 @@ internal fun ProfileScreen(uiState: ProfileUiState, onEvent: (ProfileEvent) -> U
             .fillMaxSize()
             .imePadding(),
     ) {
-        if (uiState.isLoading) {
+        if (uiState.showLoading) {
             CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
         } else {
             uiState.profile.let { profile ->

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileUiState.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileUiState.kt
@@ -14,6 +14,8 @@ internal data class ProfileUiState(
 
     val originalAboutFields: Set<AboutEditorField> = profile?.aboutFields() ?: emptySet()
 
+    val showLoading = isLoading && profile == null
+
     val aboutFields: Set<AboutEditorField> = originalAboutFields.map { field ->
         val editedValue = editedAboutFields[field.type]
         if (editedValue != null) {

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileViewModel.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileViewModel.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 internal class ProfileViewModel(
-    getAvatarUrl: GetAvatarUrl,
+    private val getAvatarUrl: GetAvatarUrl,
     private val userRepository: UserRepository,
 ) : ViewModel() {
 
@@ -25,40 +25,31 @@ internal class ProfileViewModel(
     internal val uiState: StateFlow<ProfileUiState> = _uiState.asStateFlow()
 
     init {
-        fetchProfile()
-
-        getAvatarUrl()
-            .onEach { url ->
-                _uiState.update { currentState ->
-                    currentState.copy(avatarUrl = url?.toString())
-                }
-            }
-            .launchIn(viewModelScope)
+        refreshProfile()
+        collectProfile()
+        collectAvatarUrl()
     }
 
     fun onEvent(profileEvent: ProfileEvent) {
         when (profileEvent) {
             is ProfileEvent.OnProfileFieldUpdated -> updateProfileField(profileEvent.aboutField)
             ProfileEvent.OnSaveClicked -> saveChanges()
+            ProfileEvent.OnRefreshProfile -> refreshProfile()
         }
     }
 
-    private fun fetchProfile() {
+    private fun refreshProfile() {
         viewModelScope.launch {
             _uiState.update { currentState -> currentState.copy(isLoading = true) }
-            userRepository.getProfile()
-                .onSuccess { profile ->
+            userRepository.refreshProfile()
+                .onSuccess {
                     _uiState.update { currentState ->
-                        currentState.copy(
-                            isLoading = false,
-                            profile = profile,
-                            editedAboutFields = emptyMap()
-                        )
+                        currentState.copy(isLoading = false)
                     }
                 }
                 .onFailure {
                     _uiState.update { currentState ->
-                        currentState.copy(isLoading = false, profile = null)
+                        currentState.copy(isLoading = false)
                     }
                 }
         }
@@ -96,7 +87,6 @@ internal class ProfileViewModel(
                     _uiState.update { currentState ->
                         currentState.copy(
                             isSavingProfile = false,
-                            profile = updatedProfile,
                             editedAboutFields = emptyMap()
                         )
                     }
@@ -107,6 +97,28 @@ internal class ProfileViewModel(
                     }
                 }
         }
+    }
+
+    private fun collectAvatarUrl() {
+        getAvatarUrl()
+            .onEach { url ->
+                _uiState.update { currentState ->
+                    currentState.copy(avatarUrl = url?.toString())
+                }
+            }
+            .launchIn(viewModelScope)
+    }
+
+    private fun collectProfile() {
+        userRepository.getProfile()
+            .onEach { profile ->
+                _uiState.update { currentState ->
+                    currentState.copy(
+                        profile = profile,
+                    )
+                }
+            }
+            .launchIn(viewModelScope)
     }
 }
 

--- a/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileViewModelTest.kt
+++ b/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileViewModelTest.kt
@@ -11,8 +11,8 @@ import com.gravatar.restapi.models.Profile
 import com.gravatar.restapi.models.ProfileContactInfo
 import com.gravatar.types.Hash
 import io.mockk.coEvery
-import io.mockk.coJustAwait
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -21,6 +21,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.net.URI
@@ -41,25 +42,26 @@ class ProfileViewModelTest {
     private lateinit var viewModel: ProfileViewModel
 
     private val avatarUrlFlow: MutableSharedFlow<URL?> = MutableSharedFlow()
+    private val profileFlow: MutableSharedFlow<Profile?> = MutableSharedFlow()
+
+    @Before
+    fun setup() {
+        coEvery { userRepository.refreshProfile() } returns Result.success(Unit)
+
+        every { userRepository.getProfile() } returns profileFlow
+    }
 
     @Test
-    fun `when viewmodel is initialized and fetch profile finishes successfully then uiState contains profile`() =
+    fun `when viewmodel is initialized and refresh profile finishes successfully then uiState contains profile`() =
         runTest {
-            val profile = profile()
-
-            coEvery {
-                userRepository.getProfile()
-            } returns Result.success(profile)
+            coEvery { userRepository.refreshProfile() } returns Result.success(Unit)
 
             viewModel = initViewModel()
 
             viewModel.uiState.test {
-                assertEquals(ProfileUiState(isLoading = false), awaitItem())
+                assertEquals(ProfileUiState(), awaitItem())
                 assertEquals(ProfileUiState(isLoading = true), awaitItem())
-                assertEquals(
-                    ProfileUiState(isLoading = false, profile = profile),
-                    awaitItem()
-                )
+                assertEquals(ProfileUiState(isLoading = false), awaitItem())
             }
         }
 
@@ -68,9 +70,7 @@ class ProfileViewModelTest {
         runTest {
             val exception = IllegalStateException("Failed to retrieve profile")
 
-            coEvery {
-                userRepository.getProfile()
-            } returns Result.failure(exception)
+            coEvery { userRepository.refreshProfile() } returns Result.failure(exception)
 
             viewModel = initViewModel()
 
@@ -135,9 +135,7 @@ class ProfileViewModelTest {
         runTest {
             // Given
             val profile = profile()
-            coEvery {
-                userRepository.getProfile()
-            } returns Result.success(profile)
+            profileFlow.emit(profile)
             viewModel = initViewModel()
 
             advanceUntilIdle()
@@ -163,12 +161,10 @@ class ProfileViewModelTest {
         runTest {
             // Given
             val profile = profile()
-            coEvery {
-                userRepository.getProfile()
-            } returns Result.success(profile)
             viewModel = initViewModel()
-
             advanceUntilIdle()
+
+            profileFlow.emit(profile)
 
             val modifiedField = AboutEditorField(
                 type = AboutInputField.DISPLAY_NAME,
@@ -231,14 +227,10 @@ class ProfileViewModelTest {
     fun `when saveChanges succeeds then profile is updated and editedAboutFields are cleared`() = runTest {
         // Given
         val originalProfile = profile()
-        val updatedProfile = profile(displayName = "Updated Name")
-
-        coEvery {
-            userRepository.getProfile()
-        } returns Result.success(originalProfile)
 
         viewModel = initViewModel()
         advanceUntilIdle()
+        profileFlow.emit(originalProfile)
 
         val modifiedField = AboutEditorField(
             type = AboutInputField.DISPLAY_NAME,
@@ -248,7 +240,7 @@ class ProfileViewModelTest {
 
         coEvery {
             userRepository.updateProfile(any())
-        } returns Result.success(updatedProfile)
+        } returns Result.success(Unit)
 
         // When
         viewModel.onEvent(ProfileEvent.OnSaveClicked)
@@ -267,7 +259,7 @@ class ProfileViewModelTest {
 
             expectedUiState = expectedUiState.copy(
                 isSavingProfile = false,
-                profile = updatedProfile,
+                profile = originalProfile,
                 editedAboutFields = emptyMap(),
             )
             assertEquals(expectedUiState, awaitItem())
@@ -281,12 +273,10 @@ class ProfileViewModelTest {
         val originalProfile = profile()
         val exception = IllegalStateException("Update failed")
 
-        coEvery {
-            userRepository.getProfile()
-        } returns Result.success(originalProfile)
-
         viewModel = initViewModel()
         advanceUntilIdle()
+
+        profileFlow.emit(originalProfile)
 
         val modifiedField = AboutEditorField(
             type = AboutInputField.DISPLAY_NAME,
@@ -325,7 +315,6 @@ class ProfileViewModelTest {
     @Test
     fun `each avatar URL collected should be set as state`() = runTest {
         // Given
-        coJustAwait { userRepository.getProfile() }
         viewModel = initViewModel()
         advanceUntilIdle()
 
@@ -335,7 +324,7 @@ class ProfileViewModelTest {
 
         // Then
         viewModel.uiState.test {
-            assertEquals(ProfileUiState(isLoading = true, avatarUrl = avatarUrl.toString()), awaitItem())
+            assertEquals(ProfileUiState(avatarUrl = avatarUrl.toString()), awaitItem())
         }
     }
 

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/RealProfileRepository.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/RealProfileRepository.kt
@@ -6,6 +6,8 @@ import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
 import com.gravatar.restapi.models.Profile
 import com.gravatar.restapi.models.UpdateProfileRequest
 import com.gravatar.services.ProfileService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 internal class RealProfileRepository(
     private val profileService: ProfileService,
@@ -24,22 +26,18 @@ internal class RealProfileRepository(
         )
     }
 
-    override suspend fun get(): Result<Profile> {
-        val profileEntity = profileDao.getProfile()
-        return if (profileEntity != null) {
-            Result.success(profileEntity.toProfile())
-        } else {
-            fetchProfile()
-        }
+    override fun get(): Flow<Profile?> {
+        return profileDao.getProfile()
+            .map { entity -> entity?.toProfile() }
     }
 
-    override suspend fun update(updateRequest: UpdateProfileRequest): Result<Profile> {
+    override suspend fun update(updateRequest: UpdateProfileRequest): Result<Unit> {
         val token = tokenStorage.getToken()
         return if (token != null) {
             val result = profileService.updateProfileCatching(token, updateRequest).valueOrNull()
             if (result != null) {
                 profileDao.insertProfile(ProfileEntity.fromProfile(result))
-                Result.success(result)
+                Result.success(Unit)
             } else {
                 Result.failure(IllegalStateException("Failed to update profile"))
             }

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/RealUserRepository.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/RealUserRepository.kt
@@ -9,6 +9,8 @@ import com.gravatar.services.AvatarService
 import com.gravatar.services.ErrorType
 import com.gravatar.services.GravatarResult
 import com.gravatar.types.Hash
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
 import java.io.File
 
 internal class RealUserRepository(
@@ -17,11 +19,14 @@ internal class RealUserRepository(
     private val profileRepository: ProfileRepository
 ) : UserRepository {
 
+    override suspend fun refreshProfile(): Result<Unit> {
+        return profileRepository.refreshUserProfile()
+    }
+
     override suspend fun selectAvatar(avatarId: String): Result<Unit> {
         val token = tokenStorage.getToken()
         return if (token != null) {
-            val result = profileRepository.get()
-                .getOrNull()
+            val result = getOrFetchProfile()
                 ?.let { profile ->
                     avatarService.setAvatarCatching(
                         oauthToken = token,
@@ -42,8 +47,7 @@ internal class RealUserRepository(
     override suspend fun getAvatars(): Result<List<Avatar>> {
         val token = tokenStorage.getToken()
         return if (token != null) {
-            val avatars = profileRepository.get()
-                .getOrNull()
+            val avatars = getOrFetchProfile()
                 ?.let { profile ->
                     avatarService.retrieveCatching(
                         oauthToken = token,
@@ -60,19 +64,18 @@ internal class RealUserRepository(
         }
     }
 
-    override suspend fun getProfile(): Result<Profile> {
+    override fun getProfile(): Flow<Profile?> {
         return profileRepository.get()
     }
 
-    override suspend fun updateProfile(updateRequest: UpdateProfileRequest): Result<Profile> {
+    override suspend fun updateProfile(updateRequest: UpdateProfileRequest): Result<Unit> {
         return profileRepository.update(updateRequest)
     }
 
     override suspend fun uploadAvatar(avatarFile: File): GravatarResult<Avatar, ErrorType> {
         val token = tokenStorage.getToken()
         return if (token != null) {
-            profileRepository.get()
-                .getOrNull()
+            getOrFetchProfile()
                 ?.let { profile ->
                     avatarService.uploadCatching(
                         file = avatarFile,
@@ -101,5 +104,16 @@ internal class RealUserRepository(
         } else {
             Result.failure(IllegalStateException("User is not logged in"))
         }
+    }
+
+    // Retrieves the profile, either from local storage or by refreshing it if not available
+    private suspend fun getOrFetchProfile(): Profile? {
+        val localProfile = profileRepository.get().firstOrNull()
+        return localProfile
+            ?: profileRepository.refreshUserProfile()
+                .fold(
+                    onSuccess = { profileRepository.get().firstOrNull() },
+                    onFailure = { null }
+                )
     }
 }

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/database/ProfileDao.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/database/ProfileDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.gravatar.app.usercomponent.data.database.model.ProfileEntity
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ProfileDao {
@@ -13,7 +14,7 @@ interface ProfileDao {
     suspend fun insertProfile(profile: ProfileEntity)
 
     @Query("SELECT * FROM user_profiles LIMIT 1")
-    suspend fun getProfile(): ProfileEntity?
+    fun getProfile(): Flow<ProfileEntity?>
 
     @Query("DELETE FROM user_profiles")
     suspend fun delete()

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/repository/ProfileRepository.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/repository/ProfileRepository.kt
@@ -2,14 +2,15 @@ package com.gravatar.app.usercomponent.domain.repository
 
 import com.gravatar.restapi.models.Profile
 import com.gravatar.restapi.models.UpdateProfileRequest
+import kotlinx.coroutines.flow.Flow
 
 internal interface ProfileRepository {
 
     suspend fun refreshUserProfile(): Result<Unit>
 
-    suspend fun get(): Result<Profile>
+    fun get(): Flow<Profile?>
 
-    suspend fun update(updateRequest: UpdateProfileRequest): Result<Profile>
+    suspend fun update(updateRequest: UpdateProfileRequest): Result<Unit>
 
     suspend fun delete()
 }

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/repository/UserRepository.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/repository/UserRepository.kt
@@ -5,17 +5,20 @@ import com.gravatar.restapi.models.Profile
 import com.gravatar.restapi.models.UpdateProfileRequest
 import com.gravatar.services.ErrorType
 import com.gravatar.services.GravatarResult
+import kotlinx.coroutines.flow.Flow
 import java.io.File
 
 interface UserRepository {
+
+    suspend fun refreshProfile(): Result<Unit>
 
     suspend fun selectAvatar(avatarId: String): Result<Unit>
 
     suspend fun getAvatars(): Result<List<Avatar>>
 
-    suspend fun getProfile(): Result<Profile>
+    fun getProfile(): Flow<Profile?>
 
-    suspend fun updateProfile(updateRequest: UpdateProfileRequest): Result<Profile>
+    suspend fun updateProfile(updateRequest: UpdateProfileRequest): Result<Unit>
 
     suspend fun uploadAvatar(avatarFile: File): GravatarResult<Avatar, ErrorType>
 

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/GetAvatarUrlUseCase.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/GetAvatarUrlUseCase.kt
@@ -5,6 +5,8 @@ import com.gravatar.app.usercomponent.data.AvatarCacheBusterStorage
 import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
 import com.gravatar.types.Hash
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import java.net.URL
 
@@ -15,9 +17,9 @@ internal class GetAvatarUrlUseCase(
 
     override fun invoke(): Flow<URL?> {
         return avatarCacheBusterStorage.getAvatarCacheBuster()
-            .map { cacheBuster ->
-                val hash: String? = profileRepository.get()
-                    .getOrNull()?.hash
+            .combine(
+                profileRepository.get().map { it?.hash }.distinctUntilChanged()
+            ) { cacheBuster, hash ->
                 hash?.let {
                     AvatarUrl(
                         hash = Hash(it),

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/RealProfileRepositoryTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/RealProfileRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.gravatar.app.usercomponent.data
 
+import app.cash.turbine.test
 import com.gravatar.app.testUtils.CoroutineTestRule
 import com.gravatar.app.usercomponent.data.database.ProfileDao
 import com.gravatar.app.usercomponent.data.database.model.ProfileEntity
@@ -12,8 +13,11 @@ import com.gravatar.services.ProfileService
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -105,58 +109,17 @@ class RealProfileRepositoryTest {
         val profileEntity = ProfileEntity.fromProfile(profile)
         tokenStorage.saveToken(testToken)
 
-        coEvery { profileDao.getProfile() } returns profileEntity
+        every { profileDao.getProfile() } returns flow { emit(profileEntity) }
 
         // When
-        val result = repository.get()
-
-        // Then
-        assertTrue(result.isSuccess)
-        assertEquals(profile, result.getOrNull())
-
-        // Verify DAO was called and service was not called
-        coVerify { profileDao.getProfile() }
-        coVerify(exactly = 0) { profileService.retrieveAuthenticatedCatching(any()) }
-    }
-
-    @Test
-    fun `get should fetch profile when database is empty`() = runTest {
-        // Given
-        val profile = createTestProfile()
-        tokenStorage.saveToken(testToken)
-
-        coEvery { profileDao.getProfile() } returns null
-        val profileResult = GravatarResult.Success<Profile, ErrorType>(profile)
-        coEvery { profileService.retrieveAuthenticatedCatching(testToken) } returns profileResult
-        coJustRun { profileDao.insertProfile(any()) }
-
-        // When
-        val result = repository.get()
-
-        // Then
-        assertTrue(result.isSuccess)
-        assertEquals(profile, result.getOrNull())
-
-        coVerify { profileDao.getProfile() }
-        coVerify { profileService.retrieveAuthenticatedCatching(testToken) }
-        coVerify { profileDao.insertProfile(any()) }
-    }
-
-    @Test
-    fun `get should return failure when user is not logged in and database is empty`() = runTest {
-        // Given
-        tokenStorage.clearToken()
-        coEvery { profileDao.getProfile() } returns null
-
-        // When
-        val result = repository.get()
-
-        // Then
-        assertTrue(result.isFailure)
-
-        // Verify interactions
-        coVerify { profileDao.getProfile() }
-        coVerify(exactly = 0) { profileService.retrieveAuthenticatedCatching(any()) }
+        repository.get().test {
+            // Then
+            assertEquals(profile, awaitItem())
+            awaitComplete()
+            // Verify DAO was called and service was not called
+            verify { profileDao.getProfile() }
+            coVerify(exactly = 0) { profileService.retrieveAuthenticatedCatching(any()) }
+        }
     }
 
     @Test
@@ -177,7 +140,6 @@ class RealProfileRepositoryTest {
 
         // Then
         assertTrue(result.isSuccess)
-        assertEquals(profile, result.getOrNull())
 
         coVerify { profileService.updateProfileCatching(testToken, updateRequest) }
         coVerify { profileDao.insertProfile(any()) }

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/RealUserRepositoryTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/RealUserRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.gravatar.app.usercomponent.data
 
+import app.cash.turbine.test
 import com.gravatar.app.testUtils.CoroutineTestRule
 import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
 import com.gravatar.restapi.models.Avatar
@@ -11,8 +12,11 @@ import com.gravatar.services.GravatarResult
 import com.gravatar.types.Hash
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -58,9 +62,8 @@ class RealUserRepositoryTest {
             // Save token
             tokenStorage.saveToken(testToken)
 
-            // Mock profile service
-            val profileResult = Result.success(profile)
-            coEvery { profileRepository.get() } returns profileResult
+            // Mock profile repository
+            every { profileRepository.get() } returns flow { emit(profile) }
 
             // Mock avatar service
             val avatarResult = GravatarResult.Success<List<Avatar>, ErrorType>(avatars)
@@ -76,7 +79,7 @@ class RealUserRepositoryTest {
             assertEquals(avatars, result.getOrNull())
 
             // Verify interactions
-            coVerify { profileRepository.get() }
+            verify { profileRepository.get() }
             coVerify { avatarService.retrieveCatching(testToken, any<Hash>()) }
         }
 
@@ -95,7 +98,7 @@ class RealUserRepositoryTest {
         assertEquals("User is not logged in", exception?.message)
 
         // Verify no interactions with services
-        coVerify(exactly = 0) { profileRepository.get() }
+        verify(exactly = 0) { profileRepository.get() }
         coVerify(exactly = 0) {
             avatarService.retrieveCatching(
                 any(),
@@ -105,37 +108,19 @@ class RealUserRepositoryTest {
     }
 
     @Test
-    fun `getProfile should return success when user is logged in and service returns success`() =
+    fun `getProfile should return profile from profile repository`() =
         runTest {
             // Given
             val profile = createTestProfile()
-            val profileResult = Result.success(profile)
-            coEvery { profileRepository.get() } returns profileResult
+            every { profileRepository.get() } returns flow { emit(profile) }
 
             // When
-            val result = repository.getProfile()
-
-            // Then
-            assertTrue(result.isSuccess)
-            assertEquals(profile, result.getOrNull())
-            coVerify { profileRepository.get() }
-        }
-
-    @Test
-    fun `getProfile should return failure when retrieveAuthenticatedCatching returns null profile`() =
-        runTest {
-            // Given
-            val profileResult = Result.failure<Profile>(IllegalStateException("Test exception"))
-            coEvery { profileRepository.get() } returns profileResult
-
-            // When
-            val result = repository.getProfile()
-
-            // Then
-            assertTrue(result.isFailure)
-            val exception = result.exceptionOrNull()
-            assertTrue(exception is IllegalStateException)
-            coVerify { profileRepository.get() }
+            repository.getProfile().test {
+                // Then
+                assertEquals(profile, awaitItem())
+                awaitComplete()
+                verify { profileRepository.get() }
+            }
         }
 
     @Test
@@ -149,8 +134,7 @@ class RealUserRepositoryTest {
             tokenStorage.saveToken(testToken)
 
             // Mock profile service
-            val profileResult = Result.success(profile)
-            coEvery { profileRepository.get() } returns profileResult
+            coEvery { profileRepository.get() } returns flow { emit(profile) }
 
             // Mock avatar service
             val avatarResult = GravatarResult.Success<Unit, ErrorType>(Unit)
@@ -195,7 +179,7 @@ class RealUserRepositoryTest {
         assertEquals("User is not logged in", exception?.message)
 
         // Verify no interactions with services
-        coVerify(exactly = 0) { profileRepository.get() }
+        verify(exactly = 0) { profileRepository.get() }
         coVerify(exactly = 0) { avatarService.setAvatarCatching(any(), any(), any()) }
     }
 
@@ -205,8 +189,8 @@ class RealUserRepositoryTest {
         val avatarId = "test-avatar-id"
         tokenStorage.saveToken(testToken)
 
-        val profileResult = Result.failure<Profile>(IllegalStateException("Test exception"))
-        coEvery { profileRepository.get() } returns profileResult
+        coEvery { profileRepository.refreshUserProfile() } returns Result.failure(IllegalStateException("Test exception"))
+        every { profileRepository.get() } returns flow { null }
 
         // When
         val result = repository.selectAvatar(avatarId)
@@ -217,7 +201,7 @@ class RealUserRepositoryTest {
         assertTrue(exception is IllegalStateException)
 
         // Verify interactions
-        coVerify { profileRepository.get() }
+        verify { profileRepository.get() }
         coVerify(exactly = 0) { avatarService.setAvatarCatching(any(), any(), any()) }
     }
 
@@ -231,12 +215,9 @@ class RealUserRepositoryTest {
         tokenStorage.saveToken(testToken)
 
         // Mock profile service
-        val profileResult = Result.success(profile)
-        coEvery { profileRepository.get() } returns profileResult
+        coEvery { profileRepository.get() } returns flow { emit(profile) }
 
-        // Mock avatar service to return a result that is not a Success
-        val avatarResult = mockk<GravatarResult<Unit, ErrorType>>()
-        coEvery { avatarResult.valueOrNull() } returns null
+        val avatarResult = GravatarResult.Failure<Unit, ErrorType>(ErrorType.Server)
         coEvery {
             avatarService.setAvatarCatching(
                 hash = testHash,
@@ -255,7 +236,7 @@ class RealUserRepositoryTest {
         assertEquals("Failed to select avatar", exception?.message)
 
         // Verify interactions
-        coVerify { profileRepository.get() }
+        verify { profileRepository.get() }
         coVerify {
             avatarService.setAvatarCatching(
                 hash = testHash,
@@ -270,16 +251,14 @@ class RealUserRepositoryTest {
         runTest {
             // Given
             val updateRequest = UpdateProfileRequest { }
-            val updatedProfile = createTestProfile()
-            val profileResult = Result.success(updatedProfile)
-            coEvery { profileRepository.update(updateRequest) } returns profileResult
+            val updateResult = Result.success(Unit)
+            coEvery { profileRepository.update(updateRequest) } returns updateResult
 
             // When
             val result = repository.updateProfile(updateRequest)
 
             // Then
             assertTrue(result.isSuccess)
-            assertEquals(updatedProfile, result.getOrNull())
             coVerify { profileRepository.update(updateRequest) }
         }
 
@@ -311,9 +290,8 @@ class RealUserRepositoryTest {
             // Save token
             tokenStorage.saveToken(testToken)
 
-            // Mock profile service
-            val profileResult = Result.success(profile)
-            coEvery { profileRepository.get() } returns profileResult
+            // Mock profile repository
+            coEvery { profileRepository.get() } returns flow { emit(profile) }
 
             // Mock avatar service
             val avatarResult = GravatarResult.Success<Avatar, ErrorType>(uploadedAvatar)
@@ -355,7 +333,7 @@ class RealUserRepositoryTest {
         assertTrue(result is GravatarResult.Failure)
 
         // Verify no interactions with services
-        coVerify(exactly = 0) { profileRepository.get() }
+        verify(exactly = 0) { profileRepository.get() }
         coVerify(exactly = 0) { avatarService.uploadCatching(any(), any(), any()) }
     }
 
@@ -366,8 +344,8 @@ class RealUserRepositoryTest {
         tokenStorage.saveToken(testToken)
 
         // Mock profile service to return null
-        val profileResult = Result.failure<Profile>(IllegalStateException("Test exception"))
-        coEvery { profileRepository.get() } returns profileResult
+        coEvery { profileRepository.get() } returns flow { emit(null) }
+        coEvery { profileRepository.refreshUserProfile() } returns Result.failure(IllegalStateException("Test exception"))
 
         // When
         val result = repository.uploadAvatar(testFile)
@@ -376,7 +354,7 @@ class RealUserRepositoryTest {
         assertTrue(result is GravatarResult.Failure)
 
         // Verify interactions
-        coVerify { profileRepository.get() }
+        verify { profileRepository.get() }
         coVerify(exactly = 0) { avatarService.uploadCatching(any(), any(), any()) }
     }
 
@@ -390,8 +368,7 @@ class RealUserRepositoryTest {
         tokenStorage.saveToken(testToken)
 
         // Mock profile service
-        val profileResult = Result.success(profile)
-        coEvery { profileRepository.get() } returns profileResult
+        coEvery { profileRepository.get() } returns flow { emit(profile) }
 
         // Mock avatar service to return a result that is not a Success
         val avatarResult = GravatarResult.Failure<Avatar, ErrorType>(ErrorType.Server)
@@ -410,7 +387,7 @@ class RealUserRepositoryTest {
         assertTrue(result is GravatarResult.Failure)
 
         // Verify interactions
-        coVerify { profileRepository.get() }
+        verify { profileRepository.get() }
         coVerify {
             avatarService.uploadCatching(
                 file = testFile,

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/database/ProfileDaoTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/database/ProfileDaoTest.kt
@@ -3,6 +3,7 @@ package com.gravatar.app.usercomponent.data.database
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import com.gravatar.app.usercomponent.data.database.model.ProfileEntity
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -43,7 +44,7 @@ class ProfileDaoTest {
 
         // When
         profileDao.insertProfile(profileEntity)
-        val retrievedProfile = profileDao.getProfile()
+        val retrievedProfile = profileDao.getProfile().firstOrNull()
 
         // Then
         assertEquals(profileEntity, retrievedProfile)
@@ -52,7 +53,7 @@ class ProfileDaoTest {
     @Test
     fun getProfileWhenEmpty() = runTest {
         // When
-        val retrievedProfile = profileDao.getProfile()
+        val retrievedProfile = profileDao.getProfile().firstOrNull()
 
         // Then
         assertNull(retrievedProfile)
@@ -67,7 +68,7 @@ class ProfileDaoTest {
         // When
         profileDao.insertProfile(profileEntity1)
         profileDao.insertProfile(profileEntity2)
-        val retrievedProfile = profileDao.getProfile()
+        val retrievedProfile = profileDao.getProfile().firstOrNull()
 
         // Then
         assertEquals(profileEntity2, retrievedProfile)
@@ -80,14 +81,14 @@ class ProfileDaoTest {
         profileDao.insertProfile(profileEntity)
 
         // Verify profile was inserted
-        val profileBeforeDelete = profileDao.getProfile()
+        val profileBeforeDelete = profileDao.getProfile().firstOrNull()
         assertEquals(profileEntity, profileBeforeDelete)
 
         // When
         profileDao.delete()
 
         // Then
-        val profileAfterDelete = profileDao.getProfile()
+        val profileAfterDelete = profileDao.getProfile().firstOrNull()
         assertNull(profileAfterDelete)
     }
 

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/GetAvatarUrlUseCaseTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/GetAvatarUrlUseCaseTest.kt
@@ -11,6 +11,7 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -52,7 +53,7 @@ class GetAvatarUrlUseCaseTest {
         // Given
         val hash = "test-hash"
         val profile = createProfile(hash)
-        coEvery { profileRepository.get() } returns Result.success(profile)
+        coEvery { profileRepository.get() } returns flow { emit(profile) }
 
         // When & Then
         getAvatarUrlUseCase().test {
@@ -65,7 +66,7 @@ class GetAvatarUrlUseCaseTest {
     @Test
     fun `invoke should return null when profile repository returns null`() = runTest {
         // Given
-        coEvery { profileRepository.get() } returns Result.failure(RuntimeException("Test exception"))
+        coEvery { profileRepository.get() } returns flow { emit(null) }
 
         // When & Then
         getAvatarUrlUseCase().test {
@@ -79,7 +80,7 @@ class GetAvatarUrlUseCaseTest {
         // Given
         val hash = "test-hash"
         val profile = createProfile(hash)
-        coEvery { profileRepository.get() } returns Result.success(profile)
+        coEvery { profileRepository.get() } returns flow { emit(profile) }
 
         // When & Then
         getAvatarUrlUseCase().test {


### PR DESCRIPTION
### Description

Refactoring the code to observe the locally stored Profile rather than pulling it when needed. 

This also closes GRA-451. The profile is refreshed in the `ProfileViewModel` init.

I haven't updated the presentation logic in this PR, but we should eventually do this:
- Show an error state when the profile == null and there's no loading - this means we need to refresh the profile as it's not available.
- Show some kind of message that the user is possibly seeing stale data when the refreshProfile fails.
- [Maybe] Show a warning when collecting the profile with some unsaved changes.

The last I've kept as maybe, because the current logic simply sets the new profile in the state, but the edited fields are not cleared - this means that the user will see the update and keep their changes. 

### Testing Steps

1. Generally, test all the flows. There's still a code that will try to fetch the profile once in the `UserRespository` when not available to get the hash, so if the profile fetch fails during login, we should recover. To test thi,s either mock the refresh during login, or remove the logic from the Login use case.
2. Test collecting a new profile with unsaved changes - I did that by changing the event sent on the save button click and modifying the profile on web.
