### PR TITLE
Fix uploadAvatar when no avatar is selected

### DIFF
--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
@@ -11,6 +11,7 @@ import com.gravatar.app.usercomponent.domain.repository.UserRepository
 import com.gravatar.app.usercomponent.domain.usecase.DeleteUserAvatar
 import com.gravatar.app.usercomponent.domain.usecase.GetAvatarUrl
 import com.gravatar.app.usercomponent.domain.usecase.SelectUserAvatar
+import com.gravatar.app.usercomponent.domain.usecase.UploadUserAvatar
 import com.gravatar.services.GravatarResult
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,10 +24,12 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
+@Suppress("LongParameterList")
 internal class GravatarViewModel(
     private val getAvatarUrl: GetAvatarUrl,
     private val selectUserAvatar: SelectUserAvatar,
     private val deleteUserAvatar: DeleteUserAvatar,
+    private val uploadUserAvatar: UploadUserAvatar,
     private val userRepository: UserRepository,
     private val fileUtils: FileUtils,
     private val imageDownloader: ImageDownloader,
@@ -120,7 +123,7 @@ internal class GravatarViewModel(
                     failedUploadDialog = null,
                 )
             }
-            when (val result = userRepository.uploadAvatar(uri.toFile())) {
+            when (val result = uploadUserAvatar(uri.toFile())) {
                 is GravatarResult.Success -> {
                     val avatar = result.value
                     fileUtils.deleteFile(uri)
@@ -135,7 +138,11 @@ internal class GravatarViewModel(
                                 )
                             },
                             uploadingAvatar = null,
+                            selectedAvatarId = if (avatar.selected == true) avatar.imageId else currentState.selectedAvatarId
                         )
+                    }
+                    if (avatar.selected == true) {
+                        _actions.send(GravatarAction.AvatarSelected)
                     }
                 }
 

--- a/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
+++ b/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
@@ -11,6 +11,7 @@ import com.gravatar.app.usercomponent.domain.repository.UserRepository
 import com.gravatar.app.usercomponent.domain.usecase.DeleteUserAvatar
 import com.gravatar.app.usercomponent.domain.usecase.GetAvatarUrl
 import com.gravatar.app.usercomponent.domain.usecase.SelectUserAvatar
+import com.gravatar.app.usercomponent.domain.usecase.UploadUserAvatar
 import com.gravatar.restapi.models.Avatar
 import com.gravatar.services.ErrorType
 import com.gravatar.services.GravatarResult
@@ -34,6 +35,7 @@ import java.io.File
 import java.net.URI
 import java.net.URL
 
+@Suppress("LargeClass")
 @OptIn(ExperimentalCoroutinesApi::class)
 class GravatarViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
@@ -47,6 +49,7 @@ class GravatarViewModelTest {
     private val userRepository: UserRepository = mockk()
     private val selectUserAvatar: SelectUserAvatar = mockk()
     private val deleteUserAvatar: DeleteUserAvatar = mockk()
+    private val uploadUserAvatar: UploadUserAvatar = mockk()
     private val fileUtils: FileUtils = mockk()
     private val imageDownloader: ImageDownloader = mockk()
     private lateinit var viewModel: GravatarViewModel
@@ -337,7 +340,7 @@ class GravatarViewModelTest {
         every { fileUtils.deleteFile(mockUri) } returns Unit
 
         val newAvatar = createAvatar(4)
-        coEvery { userRepository.uploadAvatar(file) } returns GravatarResult.Success(newAvatar)
+        coEvery { uploadUserAvatar(file) } returns GravatarResult.Success(newAvatar)
 
         // When
         viewModel.onEvent(GravatarEvent.OnImageCropped(mockUri))
@@ -361,9 +364,53 @@ class GravatarViewModelTest {
             )
         }
 
-        coVerify { userRepository.uploadAvatar(any()) }
+        coVerify { uploadUserAvatar(any()) }
         verify { fileUtils.deleteFile(mockUri) }
     }
+
+    @Test
+    fun `onEvent OnImageCropped should update selectedAvatarId and send AvatarSelected action when uploaded avatar is selected`() =
+        runTest {
+            // Given
+            val avatars = createAvatars()
+            coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+            initViewModel()
+            advanceUntilIdle()
+
+            mockkStatic("androidx.core.net.UriKt")
+            val file = mockk<File>()
+            val mockUri = mockk<Uri> {
+                every { toFile() } returns file
+            }
+            every { fileUtils.deleteFile(mockUri) } returns Unit
+
+            // Create a selected avatar
+            val selectedAvatar = createAvatar(4, isSelected = true)
+            coEvery { uploadUserAvatar(file) } returns GravatarResult.Success(selectedAvatar)
+
+            // When
+            viewModel.onEvent(GravatarEvent.OnImageCropped(mockUri))
+            advanceUntilIdle()
+
+            // Then
+            // Verify the uiState is updated with the selectedAvatarId
+            viewModel.uiState.test {
+                val expectedState = GravatarUiState(
+                    avatars = listOf(selectedAvatar) + avatars.filter { it.imageId != selectedAvatar.imageId },
+                    uploadingAvatar = null,
+                    selectedAvatarId = selectedAvatar.imageId
+                )
+                assertEquals(expectedState, awaitItem())
+            }
+
+            // Verify the AvatarSelected action is sent
+            viewModel.actions.test {
+                assertEquals(GravatarAction.AvatarSelected, awaitItem())
+            }
+
+            coVerify { uploadUserAvatar(any()) }
+            verify { fileUtils.deleteFile(mockUri) }
+        }
 
     @Test
     fun `onEvent OnImageCropped should handle failure`() = runTest {
@@ -381,7 +428,7 @@ class GravatarViewModelTest {
         every { fileUtils.deleteFile(mockUri) } returns Unit
 
         coEvery {
-            userRepository.uploadAvatar(any())
+            uploadUserAvatar(any())
         } returns GravatarResult.Failure(ErrorType.Server)
 
         // When
@@ -412,7 +459,7 @@ class GravatarViewModelTest {
             )
         }
 
-        coVerify { userRepository.uploadAvatar(any()) }
+        coVerify { uploadUserAvatar(any()) }
     }
 
     @Test
@@ -430,7 +477,7 @@ class GravatarViewModelTest {
             every { toFile() } returns file
         }
         coEvery {
-            userRepository.uploadAvatar(any())
+            uploadUserAvatar(any())
         } returns GravatarResult.Failure(ErrorType.Server)
 
         // Trigger a failed upload
@@ -478,7 +525,7 @@ class GravatarViewModelTest {
         }
         every { fileUtils.deleteFile(mockUri) } returns Unit
         coEvery {
-            userRepository.uploadAvatar(any())
+            uploadUserAvatar(any())
         } returns GravatarResult.Failure(ErrorType.Server)
 
         // Trigger a failed upload
@@ -521,7 +568,7 @@ class GravatarViewModelTest {
             every { toFile() } returns file
         }
         coEvery {
-            userRepository.uploadAvatar(any())
+            uploadUserAvatar(any())
         } returns GravatarResult.Failure(ErrorType.Server)
 
         // Trigger a failed upload
@@ -809,9 +856,10 @@ class GravatarViewModelTest {
         viewModel = GravatarViewModel(
             getAvatarUrl = getAvatarUrl,
             selectUserAvatar = selectUserAvatar,
+            deleteUserAvatar = deleteUserAvatar,
+            uploadUserAvatar = uploadUserAvatar,
             userRepository = userRepository,
             fileUtils = fileUtils,
-            deleteUserAvatar = deleteUserAvatar,
             imageDownloader = imageDownloader,
         )
     }
@@ -822,11 +870,12 @@ class GravatarViewModelTest {
         }
     }
 
-    private fun createAvatar(id: Int): Avatar = Avatar {
+    private fun createAvatar(id: Int, isSelected: Boolean = false): Avatar = Avatar {
         imageUrl = URI.create("https://gravatar.com/avatar/test$id")
         imageId = id.toString()
         rating = Avatar.Rating.G
         altText = "alt$id"
         updatedDate = ""
+        selected = isSelected
     }
 }

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/UserComponentModule.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/UserComponentModule.kt
@@ -21,6 +21,8 @@ import com.gravatar.app.usercomponent.domain.usecase.Logout
 import com.gravatar.app.usercomponent.domain.usecase.LogoutUseCase
 import com.gravatar.app.usercomponent.domain.usecase.SelectAvatarUseCase
 import com.gravatar.app.usercomponent.domain.usecase.SelectUserAvatar
+import com.gravatar.app.usercomponent.domain.usecase.UploadAvatarUseCase
+import com.gravatar.app.usercomponent.domain.usecase.UploadUserAvatar
 import com.gravatar.services.AvatarService
 import com.gravatar.services.ProfileService
 import org.koin.core.module.dsl.bind
@@ -38,6 +40,7 @@ val userComponentModule = module {
     factoryOf(::GetAvatarUrlUseCase) { bind<GetAvatarUrl>() }
     factoryOf(::SelectAvatarUseCase) { bind<SelectUserAvatar>() }
     factoryOf(::DeleteUserAvatarUseCase) { bind<DeleteUserAvatar>() }
+    factoryOf(::UploadAvatarUseCase) { bind<UploadUserAvatar>() }
     factoryOf(::WordPressClient)
     singleOf(::InMemoryUserSessionPersistence) { bind<UserSessionPersistence>() }
     single { ProfileService() }

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/UploadUserAvatarUseCase.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/UploadUserAvatarUseCase.kt
@@ -1,0 +1,28 @@
+package com.gravatar.app.usercomponent.domain.usecase
+
+import com.gravatar.app.clock.AppClock
+import com.gravatar.app.usercomponent.data.AvatarCacheBusterStorage
+import com.gravatar.app.usercomponent.domain.repository.UserRepository
+import com.gravatar.restapi.models.Avatar
+import com.gravatar.services.ErrorType
+import com.gravatar.services.GravatarResult
+import java.io.File
+
+internal class UploadAvatarUseCase(
+    private val userRepository: UserRepository,
+    private val avatarCacheBusterStorage: AvatarCacheBusterStorage,
+    private val clock: AppClock
+) : UploadUserAvatar {
+
+    override suspend fun invoke(avatarFile: File): GravatarResult<Avatar, ErrorType> {
+        val result = userRepository.uploadAvatar(avatarFile)
+        if (result is GravatarResult.Success && result.value.selected == true) {
+            avatarCacheBusterStorage.saveAvatarCacheBuster(clock.now().toString())
+        }
+        return result
+    }
+}
+
+interface UploadUserAvatar {
+    suspend operator fun invoke(avatarFile: File): GravatarResult<Avatar, ErrorType>
+}

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/di/UserComponentModuleTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/di/UserComponentModuleTest.kt
@@ -6,6 +6,7 @@ import com.gravatar.app.usercomponent.data.InMemoryUserSessionPersistence
 import com.gravatar.app.usercomponent.data.WordPressClient
 import com.gravatar.app.usercomponent.domain.usecase.DeleteUserAvatarUseCase
 import com.gravatar.app.usercomponent.domain.usecase.SelectAvatarUseCase
+import com.gravatar.app.usercomponent.domain.usecase.UploadAvatarUseCase
 import kotlinx.coroutines.CoroutineScope
 import org.junit.Test
 import org.koin.core.annotation.KoinExperimentalAPI
@@ -24,7 +25,8 @@ class UserComponentModuleTest : KoinTest {
                 definition<WordPressClient>(DispatcherProvider::class),
                 definition<InMemoryUserSessionPersistence>(CoroutineScope::class, DispatcherProvider::class),
                 definition<SelectAvatarUseCase>(AppClock::class),
-                definition<DeleteUserAvatarUseCase>(AppClock::class)
+                definition<DeleteUserAvatarUseCase>(AppClock::class),
+                definition<UploadAvatarUseCase>(AppClock::class),
             )
         )
     }

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/UploadAvatarUseCaseTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/UploadAvatarUseCaseTest.kt
@@ -1,0 +1,129 @@
+package com.gravatar.app.usercomponent.domain.usecase
+
+import com.gravatar.app.clock.AppClock
+import com.gravatar.app.testUtils.CoroutineTestRule
+import com.gravatar.app.usercomponent.data.AvatarCacheBusterStorage
+import com.gravatar.app.usercomponent.domain.repository.UserRepository
+import com.gravatar.restapi.models.Avatar
+import com.gravatar.services.ErrorType
+import com.gravatar.services.GravatarResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+import java.net.URI
+
+@ExperimentalCoroutinesApi
+class UploadAvatarUseCaseTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    var coroutineTestRule = CoroutineTestRule(testDispatcher)
+
+    private lateinit var uploadAvatarUseCase: UploadAvatarUseCase
+    private val userRepository = mockk<UserRepository>()
+    private val avatarCacheBusterStorage = mockk<AvatarCacheBusterStorage>()
+    private val clock = mockk<AppClock>()
+
+    private val testAvatarFile = mockk<File>()
+    private val testTimestamp = 1234567890L
+
+    @Before
+    fun setup() {
+        every { clock.now() } returns testTimestamp
+        coEvery { avatarCacheBusterStorage.saveAvatarCacheBuster(any()) } returns Unit
+
+        uploadAvatarUseCase = UploadAvatarUseCase(
+            userRepository = userRepository,
+            avatarCacheBusterStorage = avatarCacheBusterStorage,
+            clock = clock
+        )
+    }
+
+    @Test
+    fun `invoke should call userRepository uploadAvatar with correct file`() = runTest {
+        // Given
+        coEvery { userRepository.uploadAvatar(any()) } returns GravatarResult.Success(createTestAvatar())
+
+        // When
+        uploadAvatarUseCase(testAvatarFile)
+
+        // Then
+        coVerify { userRepository.uploadAvatar(testAvatarFile) }
+    }
+
+    @Test
+    fun `invoke should return success result when userRepository returns success`() = runTest {
+        val testAvatar = createTestAvatar()
+        // Given
+        coEvery { userRepository.uploadAvatar(any()) } returns GravatarResult.Success(testAvatar)
+
+        // When
+        val result = uploadAvatarUseCase(testAvatarFile)
+
+        // Then
+        assert(result is GravatarResult.Success)
+        assert((result as GravatarResult.Success).value == testAvatar)
+    }
+
+    @Test
+    fun `invoke should return failure result when userRepository returns failure`() = runTest {
+        // Given
+        val errorType = ErrorType.Server
+        coEvery { userRepository.uploadAvatar(any()) } returns GravatarResult.Failure(errorType)
+
+        // When
+        val result = uploadAvatarUseCase(testAvatarFile)
+
+        // Then
+        assert((result as GravatarResult.Failure).error == errorType)
+        coVerify(exactly = 0) { avatarCacheBusterStorage.saveAvatarCacheBuster(any()) }
+    }
+
+    @Test
+    fun `invoke should save avatar cache buster when upload is successful and avatar is selected`() = runTest {
+        // Given
+        val selectedAvatar = createTestAvatar(isSelected = true)
+        coEvery { userRepository.uploadAvatar(any()) } returns GravatarResult.Success(selectedAvatar)
+
+        // When
+        val result = uploadAvatarUseCase(testAvatarFile)
+
+        // Then
+        assert(result is GravatarResult.Success)
+        verify { clock.now() }
+        coVerify { avatarCacheBusterStorage.saveAvatarCacheBuster(testTimestamp.toString()) }
+    }
+
+    @Test
+    fun `invoke should not save avatar cache buster when upload is successful but avatar is not selected`() = runTest {
+        // Given
+        val nonSelectedAvatar = createTestAvatar() // Already has selected = false
+        coEvery { userRepository.uploadAvatar(any()) } returns GravatarResult.Success(nonSelectedAvatar)
+
+        // When
+        val result = uploadAvatarUseCase(testAvatarFile)
+
+        // Then
+        assert(result is GravatarResult.Success)
+        coVerify(exactly = 0) { avatarCacheBusterStorage.saveAvatarCacheBuster(any()) }
+    }
+
+    private fun createTestAvatar(isSelected: Boolean = false): Avatar = Avatar {
+        imageUrl = URI.create("https://gravatar.com/avatar/test123")
+        imageId = "test123"
+        rating = Avatar.Rating.G
+        altText = "Test Avatar"
+        updatedDate = "2023-01-01"
+        selected = isSelected
+    }
+}


### PR DESCRIPTION
### Description

When a new avatar is uploaded, we need to check if that avatar has been selected and update our persistence if necessary.

https://github.com/user-attachments/assets/351d6e21-44f8-4cdc-93ad-9889b10850a8

Previously to this PR, we weren't reflecting the real status after uploading a new avatar.

### Testing Steps

- In the Gravatar Tab, delete your currently selected avatar
- Upload a new avatar with either of the options (Camera or Photos)
- Verify the new avatar is shown in the headers and as the selected avatar
- Upload a different avatar with either of the options (Camera or Photos)
- Verify there is no change in the selected avatar