### PR TITLE
Add missing notification Snackbars

### DIFF
--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/navigation/HomeNavigation.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/navigation/HomeNavigation.kt
@@ -21,7 +21,7 @@ internal fun HomeNavigation(
         }
 
         composable<HomeDestination.Profile> {
-            ProfileScreen()
+            ProfileScreen(snackbarHostState = snackbarHostState)
         }
 
         composable<HomeDestination.Share> {

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarAction.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarAction.kt
@@ -7,4 +7,6 @@ sealed class GravatarAction {
     data class LaunchImageCropper(val imageUri: Uri, val tempFile: File) : GravatarAction()
     data object AvatarSelected : GravatarAction()
     data object AvatarSelectionFailed : GravatarAction()
+    data object AvatarDeleted : GravatarAction()
+    data object AvatarDeletionFailed : GravatarAction()
 }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarAction.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarAction.kt
@@ -9,4 +9,6 @@ sealed class GravatarAction {
     data object AvatarSelectionFailed : GravatarAction()
     data object AvatarDeleted : GravatarAction()
     data object AvatarDeletionFailed : GravatarAction()
+    data object DownloadManagerNotAvailable : GravatarAction()
+    data object AvatarDownloadStarted : GravatarAction()
 }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
@@ -304,6 +304,7 @@ internal fun GravatarScreen(
     }
 }
 
+@Suppress("LongMethod")
 private fun GravatarAction.handle(
     context: Context,
     uCropLauncher: ActivityResultLauncher<Intent>,
@@ -353,6 +354,25 @@ private fun GravatarAction.handle(
                     message = context.getString(R.string.gravatar_tab_avatar_deletion_failed),
                     withDismissAction = true,
                     snackbarType = SnackbarType.Error,
+                )
+            }
+        }
+
+        GravatarAction.DownloadManagerNotAvailable -> {
+            scope.launch {
+                snackbarHostState.showGravatarSnackbar(
+                    message = context.getString(R.string.gravatar_tab_download_manager_not_available),
+                    withDismissAction = true,
+                    snackbarType = SnackbarType.Error,
+                )
+            }
+        }
+
+        GravatarAction.AvatarDownloadStarted -> {
+            scope.launch {
+                snackbarHostState.showGravatarSnackbar(
+                    message = context.getString(R.string.gravatar_tab_avatar_download_started),
+                    withDismissAction = true,
                 )
             }
         }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
@@ -337,6 +337,25 @@ private fun GravatarAction.handle(
                 )
             }
         }
+
+        GravatarAction.AvatarDeleted -> {
+            scope.launch {
+                snackbarHostState.showGravatarSnackbar(
+                    message = context.getString(R.string.gravatar_tab_avatar_deleted_successfully),
+                    withDismissAction = true,
+                )
+            }
+        }
+
+        GravatarAction.AvatarDeletionFailed -> {
+            scope.launch {
+                snackbarHostState.showGravatarSnackbar(
+                    message = context.getString(R.string.gravatar_tab_avatar_deletion_failed),
+                    withDismissAction = true,
+                    snackbarType = SnackbarType.Error,
+                )
+            }
+        }
     }
 }
 

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
@@ -292,7 +292,7 @@ internal class GravatarViewModel(
                     is GravatarResult.Failure -> {
                         when (result.error) {
                             DownloadManagerError.DOWNLOAD_MANAGER_NOT_AVAILABLE -> {
-                                // Notify the UI that the download manager is not available - We should update tests to handle this case
+                                _actions.send(GravatarAction.DownloadManagerNotAvailable)
                             }
 
                             DownloadManagerError.DOWNLOAD_MANAGER_DISABLED -> {
@@ -302,7 +302,7 @@ internal class GravatarViewModel(
                     }
 
                     is GravatarResult.Success -> {
-                        // Notify the UI in order to show a confirmation - We should update tests to handle this case
+                        _actions.send(GravatarAction.AvatarDownloadStarted)
                     }
                 }
             }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
@@ -252,10 +252,10 @@ internal class GravatarViewModel(
                 }
                 deleteUserAvatar(avatarId, isSelectedAvatar)
                     .onSuccess { result ->
-                        // NOTIFY THE UI TO SHOW THE CONFIRMATION
+                        _actions.send(GravatarAction.AvatarDeleted)
                     }
                     .onFailure { error ->
-                        // NOTIFY THE UI TO SHOW AN ERROR
+                        _actions.send(GravatarAction.AvatarDeletionFailed)
 
                         _uiState.update { currentState ->
                             val updatedAvatars = currentState.avatars.orEmpty().toMutableList().apply {

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileAction.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileAction.kt
@@ -1,0 +1,6 @@
+package com.gravatar.app.homeUi.presentation.home.profile
+
+sealed class ProfileAction {
+    data object ProfileSaved : ProfileAction()
+    data object ProfileSaveFailed : ProfileAction()
+}

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileScreen.kt
@@ -9,24 +9,55 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import com.gravatar.app.homeUi.R
+import com.gravatar.app.homeUi.presentation.home.components.SnackbarType
+import com.gravatar.app.homeUi.presentation.home.components.showGravatarSnackbar
 import com.gravatar.app.homeUi.presentation.home.profile.about.AboutInputField
 import com.gravatar.app.homeUi.presentation.home.profile.about.AboutSection
 import com.gravatar.app.homeUi.presentation.home.profile.header.ProfileHeader
 import com.gravatar.app.homeUi.presentation.home.profile.header.ProfileHeaderSaveState
 import com.gravatar.extensions.defaultProfile
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
-internal fun ProfileScreen(viewModel: ProfileViewModel = koinViewModel()) {
+internal fun ProfileScreen(viewModel: ProfileViewModel = koinViewModel(), snackbarHostState: SnackbarHostState) {
+    val scope = rememberCoroutineScope()
     val uiState by viewModel.uiState.collectAsState()
+    val lifecycle = LocalLifecycleOwner.current
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.Main.immediate) {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.actions.collect { action ->
+                    action.handle(
+                        context = context,
+                        snackbarHostState = snackbarHostState,
+                        scope = scope,
+                    )
+                }
+            }
+        }
+    }
 
     ProfileScreen(
         uiState = uiState,
@@ -79,6 +110,34 @@ internal fun ProfileScreen(uiState: ProfileUiState, onEvent: (ProfileEvent) -> U
                 } else {
                     Text("There was an error retrieving the profile.")
                 }
+            }
+        }
+    }
+}
+
+private fun ProfileAction.handle(
+    context: android.content.Context,
+    snackbarHostState: SnackbarHostState,
+    scope: CoroutineScope,
+) {
+    when (this) {
+        is ProfileAction.ProfileSaved -> {
+            scope.launch {
+                snackbarHostState.showGravatarSnackbar(
+                    message = context.getString(R.string.profile_screen_saved_successfully),
+                    withDismissAction = true,
+                    snackbarType = SnackbarType.Info,
+                )
+            }
+        }
+
+        is ProfileAction.ProfileSaveFailed -> {
+            scope.launch {
+                snackbarHostState.showGravatarSnackbar(
+                    message = context.getString(R.string.profile_screen_save_fail_try_again),
+                    withDismissAction = true,
+                    snackbarType = SnackbarType.Error,
+                )
             }
         }
     }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileViewModel.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileViewModel.kt
@@ -8,11 +8,13 @@ import com.gravatar.app.usercomponent.domain.repository.UserRepository
 import com.gravatar.app.usercomponent.domain.usecase.GetAvatarUrl
 import com.gravatar.restapi.models.Profile
 import com.gravatar.restapi.models.UpdateProfileRequest
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -23,6 +25,9 @@ internal class ProfileViewModel(
 
     private val _uiState = MutableStateFlow(ProfileUiState())
     internal val uiState: StateFlow<ProfileUiState> = _uiState.asStateFlow()
+
+    private val _actions = Channel<ProfileAction>(Channel.BUFFERED)
+    val actions = _actions.receiveAsFlow()
 
     init {
         refreshProfile()
@@ -90,11 +95,13 @@ internal class ProfileViewModel(
                             editedAboutFields = emptyMap()
                         )
                     }
+                    _actions.send(ProfileAction.ProfileSaved)
                 }
                 .onFailure {
                     _uiState.update { currentState ->
                         currentState.copy(isSavingProfile = false)
                     }
+                    _actions.send(ProfileAction.ProfileSaveFailed)
                 }
         }
     }

--- a/homeUi/src/main/res/values/strings.xml
+++ b/homeUi/src/main/res/values/strings.xml
@@ -56,4 +56,6 @@
     <string name="retry_cta">Retry</string>
     <string name="gravatar_tab_unable_to_load_avatars">Unable to load avatars</string>
     <string name="gravatar_tab_unable_to_load_avatars_message">There was an issue loading your avatars. Please try again in a few minutes.</string>
+    <string name="gravatar_tab_download_manager_not_available">DownloadManager is not available.</string>
+    <string name="gravatar_tab_avatar_download_started">Image download has been queued. You\'ll receive a notification when it\'s complete.</string>
 </resources>

--- a/homeUi/src/main/res/values/strings.xml
+++ b/homeUi/src/main/res/values/strings.xml
@@ -47,6 +47,8 @@
     <string name="gravatar_tab_delete_confirmation_cancel">Cancel</string>
     <string name="gravatar_tab_avatar_updated_successfully">Avatar updated successfully</string>
     <string name="gravatar_tab_avatar_selection_failed">Ooops, there was an error selecting the avatar.</string>
+    <string name="gravatar_tab_avatar_deleted_successfully">Avatar deleted successfully.</string>
+    <string name="gravatar_tab_avatar_deletion_failed">Error deleting the avatar.</string>
     <string name="permission_required_alert_title">Permission required</string>
     <string name="permission_required_open_settings">Open settings</string>
     <string name="permission_required_dismiss">Dismiss</string>

--- a/homeUi/src/main/res/values/strings.xml
+++ b/homeUi/src/main/res/values/strings.xml
@@ -23,6 +23,8 @@
     <string name="gravatar_tab_header_more_options">More options</string>
     <string name="picker_submenu_icon_description">Expand</string>
     <string name="profile_screen_save_button">Save</string>
+    <string name="profile_screen_save_fail_try_again">Unable to save. Try again.</string>
+    <string name="profile_screen_saved_successfully">Profile updated successfully</string>
     <string name="gravatar_tab_get_a_new_look">Get a new look</string>
     <string name="gravatar_tab_camera">Camera</string>
     <string name="gravatar_tab_camera_content_description">Take new avatar with camera</string>

--- a/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
+++ b/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
@@ -622,6 +622,9 @@ class GravatarViewModelTest {
             )
             assertEquals(expectedState, awaitItem())
         }
+        viewModel.actions.test {
+            assertEquals(GravatarAction.AvatarDeleted, awaitItem())
+        }
         coVerify { deleteUserAvatar(avatarIdToDelete, false) }
     }
 
@@ -657,6 +660,9 @@ class GravatarViewModelTest {
             )
             assertEquals(expectedState, awaitItem())
         }
+        viewModel.actions.test {
+            assertEquals(GravatarAction.AvatarDeleted, expectMostRecentItem())
+        }
         coVerify { deleteUserAvatar(selectedAvatarId, true) }
     }
 
@@ -683,6 +689,9 @@ class GravatarViewModelTest {
                 avatars = avatars
             )
             assertEquals(expectedState, awaitItem())
+        }
+        viewModel.actions.test {
+            assertEquals(GravatarAction.AvatarDeletionFailed, awaitItem())
         }
         coVerify { deleteUserAvatar(avatarIdToDelete, false) }
     }
@@ -715,6 +724,9 @@ class GravatarViewModelTest {
                 selectedAvatarId = selectedAvatarId
             )
             assertEquals(expectedState, awaitItem())
+        }
+        viewModel.actions.test {
+            assertEquals(GravatarAction.AvatarDeletionFailed, expectMostRecentItem())
         }
         coVerify { deleteUserAvatar(selectedAvatarId, true) }
     }

--- a/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
+++ b/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
@@ -818,6 +818,9 @@ class GravatarViewModelTest {
 
         // Then
         coVerify { imageDownloader.downloadImage(avatarUrl) }
+        viewModel.actions.test {
+            assertEquals(GravatarAction.AvatarDownloadStarted, awaitItem())
+        }
     }
 
     @Test
@@ -840,6 +843,9 @@ class GravatarViewModelTest {
 
         // Then
         coVerify { imageDownloader.downloadImage(avatarUrl) }
+        viewModel.actions.test {
+            assertEquals(GravatarAction.DownloadManagerNotAvailable, awaitItem())
+        }
     }
 
     @Test
@@ -862,6 +868,10 @@ class GravatarViewModelTest {
 
         // Then
         coVerify { imageDownloader.downloadImage(avatarUrl) }
+        // No action should be emitted
+        viewModel.actions.test {
+            expectNoEvents()
+        }
     }
 
     private fun initViewModel() {

--- a/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileViewModelTest.kt
+++ b/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileViewModelTest.kt
@@ -264,6 +264,12 @@ class ProfileViewModelTest {
             )
             assertEquals(expectedUiState, awaitItem())
         }
+
+        // Verify that the ProfileSaved action is emitted
+        viewModel.actions.test {
+            assertEquals(ProfileAction.ProfileSaved, awaitItem())
+        }
+
         coVerify(exactly = (1)) { userRepository.updateProfile(any()) }
     }
 
@@ -309,6 +315,12 @@ class ProfileViewModelTest {
             )
             assertEquals(expectedUiState, awaitItem())
         }
+
+        // Verify that the ProfileSaveFailed action is emitted
+        viewModel.actions.test {
+            assertEquals(ProfileAction.ProfileSaveFailed, awaitItem())
+        }
+
         coVerify(exactly = (1)) { userRepository.updateProfile(any()) }
     }
 


### PR DESCRIPTION
### Description

This is a follow-up to #43. Now we are adding the missing snackbars for the following actions:

- Profile update (success-failure)
- Avatar update (success-failure)
- Delete avatar (success-failure)
- Download Avatar (started-download manager not available)

https://github.com/user-attachments/assets/973daaa5-4627-42cc-b728-37a1e01deca1

**Note:** We are using the same messages as the SDK. 

### Testing Steps

- For each of the mentioned flows, verify that you can see the corresponding toast. For error cases, you can disable the device's network or block the request.