### PR TITLE
Don't save the state when navigating to the Log in screen

### DIFF
--- a/app/src/main/java/com/gravatar/app/navigation/RootNavigation.kt
+++ b/app/src/main/java/com/gravatar/app/navigation/RootNavigation.kt
@@ -34,6 +34,7 @@ fun RootNavigation() {
                         popTo = lastRoute,
                         shouldSaveState = true
                     )
+
                     LOGGED_OUT -> navController.navigateToRootDestination(
                         destination = RootDestination.Login,
                         popTo = lastRoute,
@@ -55,7 +56,11 @@ fun RootNavigation() {
     }
 }
 
-private fun NavHostController.navigateToRootDestination(destination: Any, popTo: Any, shouldSaveState: Boolean = true) {
+private fun NavHostController.navigateToRootDestination(
+    destination: RootDestination,
+    popTo: RootDestination,
+    shouldSaveState: Boolean = true
+) {
     navigate(destination) {
         popUpTo(popTo) {
             inclusive = true

--- a/app/src/main/java/com/gravatar/app/navigation/RootNavigation.kt
+++ b/app/src/main/java/com/gravatar/app/navigation/RootNavigation.kt
@@ -29,8 +29,16 @@ fun RootNavigation() {
                 } ?: RootDestination.Splash
 
                 when (userSession) {
-                    LOGGED_IN -> navController.navigateSavingState(RootDestination.Home, popTo = lastRoute)
-                    LOGGED_OUT -> navController.navigateSavingState(RootDestination.Login, popTo = lastRoute)
+                    LOGGED_IN -> navController.navigateToRootDestination(
+                        destination = RootDestination.Home,
+                        popTo = lastRoute,
+                        shouldSaveState = true
+                    )
+                    LOGGED_OUT -> navController.navigateToRootDestination(
+                        destination = RootDestination.Login,
+                        popTo = lastRoute,
+                        shouldSaveState = lastRoute == RootDestination.Login
+                    )
                 }
             }
     }
@@ -47,14 +55,14 @@ fun RootNavigation() {
     }
 }
 
-private fun NavHostController.navigateSavingState(destination: Any, popTo: Any) {
+private fun NavHostController.navigateToRootDestination(destination: Any, popTo: Any, shouldSaveState: Boolean = true) {
     navigate(destination) {
         popUpTo(popTo) {
             inclusive = true
-            saveState = true
+            saveState = shouldSaveState
         }
         launchSingleTop = true
-        restoreState = true
+        restoreState = shouldSaveState
     }
 }
 


### PR DESCRIPTION
### Description

Our description in the issue is:

> It looks like when you log out and log in again, the view models survive and show the previous data instantly.

That was precisely what was happening. We were always saving the state, so when the user logs out, we still save the Home destination and restore it when a new user logs in again.

When navigating to the `Login` destination, we shouldn't save the state unless the previous destination is also `Login` (which can be fired in an orientation change), as we don't want to preserve any state.

### Testing Steps

**Test 1**

1. Log in with any of your accounts (it should have some already uploaded avatars)
2. Log out
3. Log in with a different account
4. Verify you see the avatars corresponding to the second account and not the first one

**Test 2**

1. Launch the app and log out if necessary
2. Tap the `Log in` button
3. Rotate the device
4. Continue with the flow and verify you can log in as expected

Play as much as you want with the navigation, back button, orientation changes, etc.
