### PR TITLE
Handle unauthorized errors - 401

### DIFF
--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/di/HomeUiModule.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/di/HomeUiModule.kt
@@ -5,14 +5,12 @@ import com.gravatar.app.homeUi.presentation.FileUtils
 import com.gravatar.app.homeUi.presentation.home.gravatar.GravatarViewModel
 import com.gravatar.app.homeUi.presentation.home.profile.ProfileViewModel
 import com.gravatar.app.usercomponent.di.userComponentModule
-import com.gravatar.services.ProfileService
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
 val homeUiModule = module {
-    single { ProfileService() }
     factory<ImageDownloader> { ImageDownloader(androidContext()) }
     factoryOf(::FileUtils)
     viewModelOf(::ProfileViewModel)

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/interceptors/HttpResponseCode.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/interceptors/HttpResponseCode.kt
@@ -1,0 +1,5 @@
+package com.gravatar.app.usercomponent.data.interceptors
+
+internal object HttpResponseCode {
+    const val UNAUTHORIZED = 401
+}

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/interceptors/UnauthorizeInterceptor.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/interceptors/UnauthorizeInterceptor.kt
@@ -1,0 +1,34 @@
+package com.gravatar.app.usercomponent.data.interceptors
+
+import com.gravatar.app.foundations.DispatcherProvider
+import com.gravatar.app.usercomponent.domain.usecase.Logout
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * Interceptor to analyze responses for 401 errors.
+ *
+ * The logout is injected as a lazy dependency to avoid a circular dependency.
+ * ProfileService -> UnauthorizeInterceptor → LogoutUseCase → RealProfileRepository → ProfileService
+ *
+ */
+class UnauthorizeInterceptor(
+    private val applicationScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+    private val logout: Lazy<Logout>
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val response = chain.proceed(request)
+
+        if (response.code == HttpResponseCode.UNAUTHORIZED) {
+            applicationScope.launch(dispatcherProvider.io) {
+                logout.value.invoke()
+            }
+        }
+        return response
+    }
+}

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/interceptors/UnauthorizeInterceptor.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/interceptors/UnauthorizeInterceptor.kt
@@ -1,6 +1,5 @@
 package com.gravatar.app.usercomponent.data.interceptors
 
-import com.gravatar.app.foundations.DispatcherProvider
 import com.gravatar.app.usercomponent.domain.usecase.Logout
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -16,7 +15,6 @@ import okhttp3.Response
  */
 class UnauthorizeInterceptor(
     private val applicationScope: CoroutineScope,
-    private val dispatcherProvider: DispatcherProvider,
     private val logout: Lazy<Logout>
 ) : Interceptor {
 
@@ -25,7 +23,7 @@ class UnauthorizeInterceptor(
         val response = chain.proceed(request)
 
         if (response.code == HttpResponseCode.UNAUTHORIZED) {
-            applicationScope.launch(dispatcherProvider.io) {
+            applicationScope.launch {
                 logout.value.invoke()
             }
         }

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/HttpClientModule.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/HttpClientModule.kt
@@ -1,11 +1,17 @@
 package com.gravatar.app.usercomponent.di
 
+import com.gravatar.app.usercomponent.data.interceptors.UnauthorizeInterceptor
+import com.gravatar.app.usercomponent.domain.usecase.Logout
+import com.gravatar.services.AvatarService
+import com.gravatar.services.ProfileService
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
 import org.koin.dsl.module
 
 internal val httpClientModule = module {
@@ -21,4 +27,12 @@ internal val httpClientModule = module {
             }
         }
     }
+    single { UnauthorizeInterceptor(applicationScope = get<CoroutineScope>(), logout = lazy { get<Logout>() }) }
+    single {
+        OkHttpClient.Builder()
+            .addInterceptor(interceptor = get<UnauthorizeInterceptor>())
+            .build()
+    }
+    single { ProfileService(okHttpClient = get<OkHttpClient>()) }
+    single { AvatarService(okHttpClient = get<OkHttpClient>()) }
 }

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/UserComponentModule.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/UserComponentModule.kt
@@ -6,7 +6,6 @@ import com.gravatar.app.usercomponent.data.RealProfileRepository
 import com.gravatar.app.usercomponent.data.RealUserRepository
 import com.gravatar.app.usercomponent.data.UserSessionPersistence
 import com.gravatar.app.usercomponent.data.WordPressClient
-import com.gravatar.app.usercomponent.data.interceptors.UnauthorizeInterceptor
 import com.gravatar.app.usercomponent.domain.repository.AuthRepository
 import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
 import com.gravatar.app.usercomponent.domain.repository.UserRepository
@@ -24,10 +23,6 @@ import com.gravatar.app.usercomponent.domain.usecase.SelectAvatarUseCase
 import com.gravatar.app.usercomponent.domain.usecase.SelectUserAvatar
 import com.gravatar.app.usercomponent.domain.usecase.UploadAvatarUseCase
 import com.gravatar.app.usercomponent.domain.usecase.UploadUserAvatar
-import com.gravatar.services.AvatarService
-import com.gravatar.services.ProfileService
-import kotlinx.coroutines.CoroutineScope
-import okhttp3.OkHttpClient
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.singleOf
@@ -46,14 +41,6 @@ val userComponentModule = module {
     factoryOf(::UploadAvatarUseCase) { bind<UploadUserAvatar>() }
     factoryOf(::WordPressClient)
     singleOf(::InMemoryUserSessionPersistence) { bind<UserSessionPersistence>() }
-    single { UnauthorizeInterceptor(applicationScope = get<CoroutineScope>(), logout = lazy { get<Logout>() }) }
-    single {
-        OkHttpClient.Builder()
-            .addInterceptor(interceptor = get<UnauthorizeInterceptor>())
-            .build()
-    }
-    single { ProfileService(okHttpClient = get<OkHttpClient>()) }
-    single { AvatarService(okHttpClient = get<OkHttpClient>()) }
     includes(httpClientModule)
     includes(datastoreModule)
     includes(databaseModule)

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/UserComponentModule.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/UserComponentModule.kt
@@ -1,6 +1,5 @@
 package com.gravatar.app.usercomponent.di
 
-import com.gravatar.app.foundations.DispatcherProvider
 import com.gravatar.app.usercomponent.data.InMemoryUserSessionPersistence
 import com.gravatar.app.usercomponent.data.RealAuthRepository
 import com.gravatar.app.usercomponent.data.RealProfileRepository
@@ -47,7 +46,7 @@ val userComponentModule = module {
     factoryOf(::UploadAvatarUseCase) { bind<UploadUserAvatar>() }
     factoryOf(::WordPressClient)
     singleOf(::InMemoryUserSessionPersistence) { bind<UserSessionPersistence>() }
-    single { UnauthorizeInterceptor(get<CoroutineScope>(), get<DispatcherProvider>(), lazy { get<Logout>() }) }
+    single { UnauthorizeInterceptor(applicationScope = get<CoroutineScope>(), logout = lazy { get<Logout>() }) }
     single {
         OkHttpClient.Builder()
             .addInterceptor(interceptor = get<UnauthorizeInterceptor>())

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/UserComponentModule.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/UserComponentModule.kt
@@ -1,11 +1,13 @@
 package com.gravatar.app.usercomponent.di
 
+import com.gravatar.app.foundations.DispatcherProvider
 import com.gravatar.app.usercomponent.data.InMemoryUserSessionPersistence
 import com.gravatar.app.usercomponent.data.RealAuthRepository
 import com.gravatar.app.usercomponent.data.RealProfileRepository
 import com.gravatar.app.usercomponent.data.RealUserRepository
 import com.gravatar.app.usercomponent.data.UserSessionPersistence
 import com.gravatar.app.usercomponent.data.WordPressClient
+import com.gravatar.app.usercomponent.data.interceptors.UnauthorizeInterceptor
 import com.gravatar.app.usercomponent.domain.repository.AuthRepository
 import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
 import com.gravatar.app.usercomponent.domain.repository.UserRepository
@@ -25,6 +27,8 @@ import com.gravatar.app.usercomponent.domain.usecase.UploadAvatarUseCase
 import com.gravatar.app.usercomponent.domain.usecase.UploadUserAvatar
 import com.gravatar.services.AvatarService
 import com.gravatar.services.ProfileService
+import kotlinx.coroutines.CoroutineScope
+import okhttp3.OkHttpClient
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.singleOf
@@ -43,8 +47,14 @@ val userComponentModule = module {
     factoryOf(::UploadAvatarUseCase) { bind<UploadUserAvatar>() }
     factoryOf(::WordPressClient)
     singleOf(::InMemoryUserSessionPersistence) { bind<UserSessionPersistence>() }
-    single { ProfileService() }
-    single { AvatarService() }
+    single { UnauthorizeInterceptor(get<CoroutineScope>(), get<DispatcherProvider>(), lazy { get<Logout>() }) }
+    single {
+        OkHttpClient.Builder()
+            .addInterceptor(interceptor = get<UnauthorizeInterceptor>())
+            .build()
+    }
+    single { ProfileService(okHttpClient = get<OkHttpClient>()) }
+    single { AvatarService(okHttpClient = get<OkHttpClient>()) }
     includes(httpClientModule)
     includes(datastoreModule)
     includes(databaseModule)

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/interceptors/UnauthorizeInterceptorTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/interceptors/UnauthorizeInterceptorTest.kt
@@ -1,13 +1,11 @@
 package com.gravatar.app.usercomponent.data.interceptors
 
-import com.gravatar.app.foundations.DispatcherProvider
 import com.gravatar.app.testUtils.CoroutineTestRule
 import com.gravatar.app.usercomponent.domain.usecase.Logout
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -32,17 +30,11 @@ class UnauthorizeInterceptorTest {
     private lateinit var unauthorizeInterceptor: UnauthorizeInterceptor
     private val logout = mockk<Lazy<Logout>>()
     private val applicationScope = CoroutineScope(testDispatcher)
-    private val testDispatcherProvider = object : DispatcherProvider {
-        override val main: CoroutineDispatcher = testDispatcher
-        override val io: CoroutineDispatcher = testDispatcher
-        override val default: CoroutineDispatcher = testDispatcher
-    }
 
     @Before
     fun setup() {
         unauthorizeInterceptor = UnauthorizeInterceptor(
             applicationScope = applicationScope,
-            dispatcherProvider = testDispatcherProvider,
             logout = logout
         )
     }

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/interceptors/UnauthorizeInterceptorTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/data/interceptors/UnauthorizeInterceptorTest.kt
@@ -1,0 +1,119 @@
+package com.gravatar.app.usercomponent.data.interceptors
+
+import com.gravatar.app.foundations.DispatcherProvider
+import com.gravatar.app.testUtils.CoroutineTestRule
+import com.gravatar.app.usercomponent.domain.usecase.Logout
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import okhttp3.Interceptor
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class UnauthorizeInterceptorTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    var coroutineTestRule = CoroutineTestRule(testDispatcher)
+
+    private lateinit var unauthorizeInterceptor: UnauthorizeInterceptor
+    private val logout = mockk<Lazy<Logout>>()
+    private val applicationScope = CoroutineScope(testDispatcher)
+    private val testDispatcherProvider = object : DispatcherProvider {
+        override val main: CoroutineDispatcher = testDispatcher
+        override val io: CoroutineDispatcher = testDispatcher
+        override val default: CoroutineDispatcher = testDispatcher
+    }
+
+    @Before
+    fun setup() {
+        unauthorizeInterceptor = UnauthorizeInterceptor(
+            applicationScope = applicationScope,
+            dispatcherProvider = testDispatcherProvider,
+            logout = logout
+        )
+    }
+
+    @Test
+    fun `should invoke logout when response code is 401`() = runTest {
+        // Given
+        val chain = mockk<Interceptor.Chain>()
+        val request = Request.Builder().url("https://example.com").build()
+        val response = Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(HttpResponseCode.UNAUTHORIZED)
+            .message("Unauthorized")
+            .build()
+
+        // When
+        coEvery { logout.value.invoke() } returns Unit
+        every { chain.request() } returns request
+        every { chain.proceed(request) } returns response
+
+        unauthorizeInterceptor.intercept(chain)
+
+        // Then
+        advanceUntilIdle()
+        coVerify(exactly = 1) { logout.value.invoke() }
+    }
+
+    @Test
+    fun `should not invoke logout when response code is not 401`() = runTest {
+        // Given
+        val chain = mockk<Interceptor.Chain>()
+        val request = Request.Builder().url("https://example.com").build()
+        val response = Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(404)
+            .message("Not Found")
+            .build()
+
+        // When
+        every { chain.request() } returns request
+        every { chain.proceed(request) } returns response
+
+        unauthorizeInterceptor.intercept(chain)
+
+        // Then
+        advanceUntilIdle()
+        coVerify(exactly = 0) { logout.value.invoke() }
+    }
+
+    @Test
+    fun `should not invoke logout when response is successful`() = runTest {
+        // Given
+        val chain = mockk<Interceptor.Chain>()
+        val request = Request.Builder().url("https://example.com").build()
+        val response = Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .build()
+
+        // When
+        every { chain.request() } returns request
+        every { chain.proceed(request) } returns response
+
+        unauthorizeInterceptor.intercept(chain)
+
+        // Then
+        advanceUntilIdle()
+        coVerify(exactly = 0) { logout.value.invoke() }
+    }
+}

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/di/UserComponentModuleTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/di/UserComponentModuleTest.kt
@@ -28,7 +28,7 @@ class UserComponentModuleTest : KoinTest {
                 definition<SelectAvatarUseCase>(AppClock::class),
                 definition<DeleteUserAvatarUseCase>(AppClock::class),
                 definition<UploadAvatarUseCase>(AppClock::class),
-                definition<UnauthorizeInterceptor>(CoroutineScope::class, DispatcherProvider::class),
+                definition<UnauthorizeInterceptor>(CoroutineScope::class),
             )
         )
     }

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/di/UserComponentModuleTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/di/UserComponentModuleTest.kt
@@ -4,6 +4,7 @@ import com.gravatar.app.clock.AppClock
 import com.gravatar.app.foundations.DispatcherProvider
 import com.gravatar.app.usercomponent.data.InMemoryUserSessionPersistence
 import com.gravatar.app.usercomponent.data.WordPressClient
+import com.gravatar.app.usercomponent.data.interceptors.UnauthorizeInterceptor
 import com.gravatar.app.usercomponent.domain.usecase.DeleteUserAvatarUseCase
 import com.gravatar.app.usercomponent.domain.usecase.SelectAvatarUseCase
 import com.gravatar.app.usercomponent.domain.usecase.UploadAvatarUseCase
@@ -27,6 +28,7 @@ class UserComponentModuleTest : KoinTest {
                 definition<SelectAvatarUseCase>(AppClock::class),
                 definition<DeleteUserAvatarUseCase>(AppClock::class),
                 definition<UploadAvatarUseCase>(AppClock::class),
+                definition<UnauthorizeInterceptor>(CoroutineScope::class, DispatcherProvider::class),
             )
         )
     }


### PR DESCRIPTION
### Description

This PR handles unauthorized errors from the server. When a 401 error is received from the server, the interceptor will perform a logout. 

### Testing Steps

- Launch the app connected to a network analyzer.
- Log in
- Override responses from the Avatar and/or Profile services to return a 401
- Verify that a logout is performed and you are redirected to the login screen
