### PR TITLE
Improve the avatar URL handling in the app

### DIFF
--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/GetAvatarUrlUseCase.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/GetAvatarUrlUseCase.kt
@@ -1,5 +1,6 @@
 package com.gravatar.app.usercomponent.domain.usecase
 
+import com.gravatar.AvatarQueryOptions
 import com.gravatar.AvatarUrl
 import com.gravatar.app.usercomponent.data.AvatarCacheBusterStorage
 import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
@@ -15,6 +16,10 @@ internal class GetAvatarUrlUseCase(
     private val avatarCacheBusterStorage: AvatarCacheBusterStorage,
 ) : GetAvatarUrl {
 
+    companion object {
+        private const val AVATAR_SIZE = 512
+    }
+
     override fun invoke(): Flow<URL?> {
         return avatarCacheBusterStorage.getAvatarCacheBuster()
             .combine(
@@ -23,6 +28,9 @@ internal class GetAvatarUrlUseCase(
                 hash?.let {
                     AvatarUrl(
                         hash = Hash(it),
+                        avatarQueryOptions = AvatarQueryOptions.Builder()
+                            .setPreferredSize(AVATAR_SIZE)
+                            .build()
                     ).url(cacheBuster)
                 }
             }

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/SelectUserAvatarUseCase.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/SelectUserAvatarUseCase.kt
@@ -1,19 +1,17 @@
 package com.gravatar.app.usercomponent.domain.usecase
 
-import com.gravatar.app.clock.AppClock
 import com.gravatar.app.usercomponent.data.AvatarCacheBusterStorage
 import com.gravatar.app.usercomponent.domain.repository.UserRepository
 
 internal class SelectAvatarUseCase(
     private val userRepository: UserRepository,
     private val avatarCacheBusterStorage: AvatarCacheBusterStorage,
-    private val clock: AppClock,
 ) : SelectUserAvatar {
 
     override suspend fun invoke(avatarId: String): Result<Unit> {
         return userRepository.selectAvatar(avatarId)
             .onSuccess {
-                avatarCacheBusterStorage.saveAvatarCacheBuster(clock.now().toString())
+                avatarCacheBusterStorage.saveAvatarCacheBuster(avatarId)
             }
     }
 }

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/UploadUserAvatarUseCase.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/UploadUserAvatarUseCase.kt
@@ -1,6 +1,5 @@
 package com.gravatar.app.usercomponent.domain.usecase
 
-import com.gravatar.app.clock.AppClock
 import com.gravatar.app.usercomponent.data.AvatarCacheBusterStorage
 import com.gravatar.app.usercomponent.domain.repository.UserRepository
 import com.gravatar.restapi.models.Avatar
@@ -11,13 +10,12 @@ import java.io.File
 internal class UploadAvatarUseCase(
     private val userRepository: UserRepository,
     private val avatarCacheBusterStorage: AvatarCacheBusterStorage,
-    private val clock: AppClock
 ) : UploadUserAvatar {
 
     override suspend fun invoke(avatarFile: File): GravatarResult<Avatar, ErrorType> {
         val result = userRepository.uploadAvatar(avatarFile)
         if (result is GravatarResult.Success && result.value.selected == true) {
-            avatarCacheBusterStorage.saveAvatarCacheBuster(clock.now().toString())
+            avatarCacheBusterStorage.saveAvatarCacheBuster(result.value.imageId)
         }
         return result
     }

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/GetAvatarUrlUseCaseTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/GetAvatarUrlUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.gravatar.app.usercomponent.domain.usecase
 
 import app.cash.turbine.test
+import com.gravatar.AvatarQueryOptions
 import com.gravatar.AvatarUrl
 import com.gravatar.app.testUtils.CoroutineTestRule
 import com.gravatar.app.usercomponent.data.AvatarCacheBusterStorage
@@ -40,6 +41,14 @@ class GetAvatarUrlUseCaseTest {
         }
     }
 
+    private val hash = "test-hash"
+    val avatarUrl = AvatarUrl(
+        hash = Hash(hash),
+        avatarQueryOptions = AvatarQueryOptions.Builder()
+            .setPreferredSize(512)
+            .build()
+    )
+
     @Before
     fun setup() {
         getAvatarUrlUseCase = GetAvatarUrlUseCase(
@@ -51,13 +60,12 @@ class GetAvatarUrlUseCaseTest {
     @Test
     fun `invoke should return URL when profile repository returns a valid hash`() = runTest {
         // Given
-        val hash = "test-hash"
         val profile = createProfile(hash)
         coEvery { profileRepository.get() } returns flow { emit(profile) }
 
         // When & Then
         getAvatarUrlUseCase().test {
-            val expectedUrl = AvatarUrl(Hash(hash)).url(null)
+            val expectedUrl = avatarUrl.url(null)
             assertEquals(expectedUrl, awaitItem())
             expectNoEvents()
         }
@@ -84,7 +92,7 @@ class GetAvatarUrlUseCaseTest {
 
         // When & Then
         getAvatarUrlUseCase().test {
-            val initialUrl = AvatarUrl(Hash(hash)).url(null)
+            val initialUrl = avatarUrl.url(null)
             assertEquals(initialUrl, awaitItem())
 
             // Update cache buster
@@ -92,7 +100,7 @@ class GetAvatarUrlUseCaseTest {
             cacheBusterFlow.emit(cacheBuster)
 
             // Should emit new URL with cache buster
-            val updatedUrl = AvatarUrl(Hash(hash)).url(cacheBuster)
+            val updatedUrl = avatarUrl.url(cacheBuster)
             assertEquals(updatedUrl, awaitItem())
 
             // Update cache buster again
@@ -100,7 +108,7 @@ class GetAvatarUrlUseCaseTest {
             cacheBusterFlow.emit(newCacheBuster)
 
             // Should emit new URL with new cache buster
-            val newUrl = AvatarUrl(Hash(hash)).url(newCacheBuster)
+            val newUrl = avatarUrl.url(newCacheBuster)
             assertEquals(newUrl, awaitItem())
 
             // No more items should be emitted

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/SelectAvatarUseCaseTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/SelectAvatarUseCaseTest.kt
@@ -1,13 +1,11 @@
 package com.gravatar.app.usercomponent.domain.usecase
 
-import com.gravatar.app.clock.AppClock
 import com.gravatar.app.testUtils.CoroutineTestRule
 import com.gravatar.app.usercomponent.data.AvatarCacheBusterStorage
 import com.gravatar.app.usercomponent.domain.repository.UserRepository
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -26,19 +24,14 @@ class SelectAvatarUseCaseTest {
     private lateinit var selectAvatarUseCase: SelectAvatarUseCase
     private val userRepository = mockk<UserRepository>()
     private val avatarCacheBusterStorage = mockk<AvatarCacheBusterStorage>()
-    private val clock = mockk<AppClock>()
 
     private val testAvatarId = "test-avatar-id"
-    private val testTimestamp = 1234567890L
 
     @Before
     fun setup() {
-        coEvery { clock.now() } returns testTimestamp
-
         selectAvatarUseCase = SelectAvatarUseCase(
             userRepository = userRepository,
             avatarCacheBusterStorage = avatarCacheBusterStorage,
-            clock = clock
         )
     }
 
@@ -46,7 +39,7 @@ class SelectAvatarUseCaseTest {
     fun `invoke should call userRepository selectAvatar with correct avatarId`() = runTest {
         // Given
         coEvery { userRepository.selectAvatar(any()) } returns Result.success(Unit)
-        coEvery { avatarCacheBusterStorage.saveAvatarCacheBuster(testTimestamp.toString()) } returns Unit
+        coEvery { avatarCacheBusterStorage.saveAvatarCacheBuster(testAvatarId) } returns Unit
 
         // When
         selectAvatarUseCase(testAvatarId)
@@ -59,15 +52,14 @@ class SelectAvatarUseCaseTest {
     fun `invoke should save avatar cache buster when userRepository returns success`() = runTest {
         // Given
         coEvery { userRepository.selectAvatar(any()) } returns Result.success(Unit)
-        coEvery { avatarCacheBusterStorage.saveAvatarCacheBuster(testTimestamp.toString()) } returns Unit
+        coEvery { avatarCacheBusterStorage.saveAvatarCacheBuster(testAvatarId) } returns Unit
 
         // When
         val result = selectAvatarUseCase(testAvatarId)
 
         // Then
         assert(result.isSuccess)
-        verify { clock.now() }
-        coVerify { avatarCacheBusterStorage.saveAvatarCacheBuster(testTimestamp.toString()) }
+        coVerify { avatarCacheBusterStorage.saveAvatarCacheBuster(testAvatarId) }
     }
 
     @Test

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/UploadAvatarUseCaseTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/UploadAvatarUseCaseTest.kt
@@ -1,6 +1,5 @@
 package com.gravatar.app.usercomponent.domain.usecase
 
-import com.gravatar.app.clock.AppClock
 import com.gravatar.app.testUtils.CoroutineTestRule
 import com.gravatar.app.usercomponent.data.AvatarCacheBusterStorage
 import com.gravatar.app.usercomponent.domain.repository.UserRepository
@@ -9,9 +8,7 @@ import com.gravatar.services.ErrorType
 import com.gravatar.services.GravatarResult
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -32,20 +29,16 @@ class UploadAvatarUseCaseTest {
     private lateinit var uploadAvatarUseCase: UploadAvatarUseCase
     private val userRepository = mockk<UserRepository>()
     private val avatarCacheBusterStorage = mockk<AvatarCacheBusterStorage>()
-    private val clock = mockk<AppClock>()
 
     private val testAvatarFile = mockk<File>()
-    private val testTimestamp = 1234567890L
 
     @Before
     fun setup() {
-        every { clock.now() } returns testTimestamp
         coEvery { avatarCacheBusterStorage.saveAvatarCacheBuster(any()) } returns Unit
 
         uploadAvatarUseCase = UploadAvatarUseCase(
             userRepository = userRepository,
             avatarCacheBusterStorage = avatarCacheBusterStorage,
-            clock = clock
         )
     }
 
@@ -100,8 +93,7 @@ class UploadAvatarUseCaseTest {
 
         // Then
         assert(result is GravatarResult.Success)
-        verify { clock.now() }
-        coVerify { avatarCacheBusterStorage.saveAvatarCacheBuster(testTimestamp.toString()) }
+        coVerify { avatarCacheBusterStorage.saveAvatarCacheBuster(selectedAvatar.imageId) }
     }
 
     @Test


### PR DESCRIPTION
### Description

This PR does two things:
1. Request a specific size of the user avatar. The default is 80x80px, which is not enough for the expanded headers.
2. Changes the logic and uses `imageId` as the cache buster when saving, uploading images. This increases the number of times we use the locally cached image, even when reselecting. 

### Testing Steps
1. Verify the avatar works as expected; you can monitor the network to confirm caching is used more often. 