### PR TITLE
Lock orientation to portrait

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,9 @@
             android:exported="true"
             android:label="@string/app_name"
             android:windowSoftInputMode="adjustResize"
-            android:theme="@style/Theme.Gravatar">
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.Gravatar"
+            tools:ignore="DiscouragedApi,LockedOrientationActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
### Description

As the title says. 

This will be ignored on large devices with Android 16+, but it will still be respected on phones.

### Testing Steps
1. Launch the app on the phone. 
2. Rotate the device. 
3. Confirm the orientation is locked at portrait.