### PR TITLE
Keep VMs alive for the main bottom tab destination 

### DIFF
--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/navigation/HomeNavigation.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/navigation/HomeNavigation.kt
@@ -15,13 +15,23 @@ internal fun HomeNavigation(
     navController: NavHostController,
     snackbarHostState: SnackbarHostState,
 ) {
-    NavHost(navController = navController, startDestination = HomeDestination.Gravatar) {
+    NavHost(
+        navController = navController,
+        route = HomeRoute::class,
+        startDestination = HomeDestination.Gravatar
+    ) {
         composable<HomeDestination.Gravatar> {
-            GravatarScreen(snackbarHostState = snackbarHostState)
+            GravatarScreen(
+                viewModelStoreOwner = navController.getBackStackEntry(HomeRoute::class),
+                snackbarHostState = snackbarHostState
+            )
         }
 
         composable<HomeDestination.Profile> {
-            ProfileScreen(snackbarHostState = snackbarHostState)
+            ProfileScreen(
+                viewModelStoreOwner = navController.getBackStackEntry(HomeRoute::class),
+                snackbarHostState = snackbarHostState
+            )
         }
 
         composable<HomeDestination.Share> {
@@ -29,6 +39,9 @@ internal fun HomeNavigation(
         }
     }
 }
+
+@Serializable
+internal object HomeRoute
 
 @Serializable
 internal sealed class HomeDestination(

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import com.gravatar.app.design.components.snackbar.SnackbarType
@@ -80,7 +81,8 @@ import java.net.URI
 
 @Composable
 internal fun GravatarScreen(
-    viewModel: GravatarViewModel = koinViewModel(),
+    viewModelStoreOwner: ViewModelStoreOwner,
+    viewModel: GravatarViewModel = koinViewModel(viewModelStoreOwner = viewModelStoreOwner),
     snackbarHostState: SnackbarHostState,
 ) {
     val logout = koinInject<Logout>()

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import com.gravatar.app.design.components.snackbar.SnackbarType
@@ -53,7 +54,11 @@ import org.koin.androidx.compose.koinViewModel
 import kotlin.math.roundToInt
 
 @Composable
-internal fun ProfileScreen(viewModel: ProfileViewModel = koinViewModel(), snackbarHostState: SnackbarHostState) {
+internal fun ProfileScreen(
+    viewModelStoreOwner: ViewModelStoreOwner,
+    viewModel: ProfileViewModel = koinViewModel(viewModelStoreOwner = viewModelStoreOwner),
+    snackbarHostState: SnackbarHostState
+) {
     val scope = rememberCoroutineScope()
     val uiState by viewModel.uiState.collectAsState()
     val lifecycle = LocalLifecycleOwner.current


### PR DESCRIPTION
### Description

What:
The UI state on the profile screen is lost after using the system back button.

Why:
Using a back button on the share or the profile tab pops up the destination, and that destroys the ViewModel related to that destination. 

How:
Create a ViewModelStoreOwner for the root navHost and pass it to each destination for ViewModel creation. 


https://github.com/user-attachments/assets/d93f4fa9-3fa1-4598-bbf8-a211c65cb5f9




### Testing Steps
1. Launch the app
2. Open the Profile tab and make some changes (Don't save them)
3. Using the system back button, go back to the first tab
4. Go back to the Profile tab
5. Confirm the changes are still there and the save button is visible
