### PR TITLE
Fix release build type

### DIFF
--- a/build-logic/convention/src/main/kotlin/GravatarAndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/GravatarAndroidLibraryConventionPlugin.kt
@@ -32,7 +32,7 @@ class GravatarAndroidLibraryConventionPlugin : Plugin<Project> {
     private fun LibraryExtension.configureBuildTypes() {
         buildTypes {
             getByName("release") {
-                isMinifyEnabled = true
+                isMinifyEnabled = false
                 proguardFiles(
                     getDefaultProguardFile("proguard-android-optimize.txt"),
                     "proguard-rules.pro",


### PR DESCRIPTION
### Description

In this [PR](https://github.com/Automattic/Gravatar-Android/pull/65), with the prototype build, it was discovered that the R8 fails when building the release variant. 

When trying to fix it, I noticed multiple errors, conflicting names (after obfuscation) - it was a bit weird and something I haven't seen before. 

It turned out, the cause of this was the `isMinifyEnabled=true` set for each library module. As far as I know, this is best to only set this in the `app` module, as the minification will be enabled on all dependencies regardless of each individual module setup. 
 
### Testing Steps

You can test this by building the `release` variant of the app. To do so, you have to add this line:
```kotlin
signingConfig = signingConfigs.getByName("debug")
```
in [this block](https://github.com/Automattic/Gravatar-Android/blob/trunk/build-logic/convention/src/main/kotlin/GravatarAndroidApplicationConventionPlugin.kt#L43).

After that, build the app and smoke test it. 