### PR TITLE
Set keyboardType for email&phone input fields

### DIFF
--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/components/ShareEditableField.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/components/ShareEditableField.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -17,6 +18,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.gravatar.app.homeUi.R
@@ -28,6 +30,7 @@ internal fun ShareEditableField(
     onValueChange: (String) -> Unit,
     switchChecked: Boolean,
     onSwitchCheckedChange: (Boolean) -> Unit,
+    keyboardType: KeyboardType = KeyboardType.Unspecified,
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -42,6 +45,9 @@ internal fun ShareEditableField(
             singleLine = true,
             cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
             modifier = Modifier.weight(1f),
+            keyboardOptions = KeyboardOptions(
+                keyboardType = keyboardType,
+            ),
             decorationBox = { innerTextField ->
                 Box(
                     modifier = Modifier

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/components/SharePrivateContactInfo.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/components/SharePrivateContactInfo.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.gravatar.app.homeUi.R
@@ -31,6 +32,7 @@ internal fun SharePrivateContactInfo(
             value = privateContactInfo.emailValue,
             onValueChange = onEmailValueChange,
             switchChecked = privateContactInfo.isEmailShared,
+            keyboardType = KeyboardType.Email,
             onSwitchCheckedChange = onEmailSwitchCheckedChange,
         )
         ShareEditableField(
@@ -38,6 +40,7 @@ internal fun SharePrivateContactInfo(
             value = privateContactInfo.phoneValue,
             onValueChange = onPhoneValueChange,
             switchChecked = privateContactInfo.isPhoneShared,
+            keyboardType = KeyboardType.Phone,
             onSwitchCheckedChange = onPhoneSwitchCheckedChange,
         )
     }


### PR DESCRIPTION
### Description

This will open the soft keyboard in a mode that suits the given input field.

Example for the KeyboardType.Phone

<img width="1280" height="2856" alt="phone_type" src="https://github.com/user-attachments/assets/86ab1fea-18fc-41bc-83f1-f0ad8a589e7b" />


### Testing Steps

1. Open the share tab, tap on the private input fields. 
2. Confirm the keyboard shows in an email or phone mode.
