### PR TITLE
Store UserSharePreferences in local storage

### DIFF
--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/ShareEvent.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/ShareEvent.kt
@@ -2,9 +2,7 @@ package com.gravatar.app.homeUi.presentation.home.share
 
 internal sealed class ShareEvent {
     data class OnEmailValueChanged(val value: String) : ShareEvent()
-    data class OnEmailSharingChanged(val isShared: Boolean) : ShareEvent()
     data class OnPhoneValueChanged(val value: String) : ShareEvent()
-    data class OnPhoneSharingChanged(val isShared: Boolean) : ShareEvent()
     data class OnUserSharePreferencesChanged(val shareFieldType: ShareFieldType) : ShareEvent()
     data object OnAboutAppClicked : ShareEvent()
     data object OnDismissAboutAppDialog : ShareEvent()

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/ShareScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/ShareScreen.kt
@@ -60,11 +60,15 @@ internal fun ShareScreen(uiState: ShareUiState, onEvent: (ShareEvent) -> Unit) {
                     .fillMaxWidth(),
             )
             SharePrivateContactInfo(
-                privateContactInfo = uiState.privateContactInfo,
+                privateContactState = uiState.privateContactState,
                 onEmailValueChange = { onEvent(ShareEvent.OnEmailValueChanged(it)) },
-                onEmailSwitchCheckedChange = { onEvent(ShareEvent.OnEmailSharingChanged(it)) },
+                onEmailSwitchCheckedChange = {
+                    onEvent(ShareEvent.OnUserSharePreferencesChanged(ShareFieldType.PrivateEmail(it)))
+                },
                 onPhoneValueChange = { onEvent(ShareEvent.OnPhoneValueChanged(it)) },
-                onPhoneSwitchCheckedChange = { onEvent(ShareEvent.OnPhoneSharingChanged(it)) },
+                onPhoneSwitchCheckedChange = {
+                    onEvent(ShareEvent.OnUserSharePreferencesChanged(ShareFieldType.PrivatePhone(it)))
+                },
                 modifier = Modifier.padding(16.dp),
             )
             ItemDivider()

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/ShareUiState.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/ShareUiState.kt
@@ -1,5 +1,6 @@
 package com.gravatar.app.homeUi.presentation.home.share
 
+import com.gravatar.app.usercomponent.domain.model.PrivateContactInfo
 import com.gravatar.app.usercomponent.domain.model.UserSharePreferences
 import com.gravatar.restapi.models.Profile
 
@@ -7,20 +8,23 @@ internal data class ShareUiState(
     val profile: Profile? = null,
     val avatarUrl: String? = null,
     val isAboutAppDialogVisible: Boolean = false,
-    val privateContactInfo: PrivateContactInfo = PrivateContactInfo(),
-    val userSharePreferences: UserSharePreferences = UserSharePreferences(
-        name = true,
-        location = true,
-        title = true,
-        organization = true,
-        description = true,
-        profileUrl = true
-    )
+    val privateContactInfo: PrivateContactInfo = PrivateContactInfo.Default,
+    val userSharePreferences: UserSharePreferences = UserSharePreferences.Default
 ) {
+
+    val privateContactState = PrivateContactState(
+        emailValue = privateContactInfo.privateEmail,
+        isEmailShared = userSharePreferences.privateEmail,
+        phoneValue = privateContactInfo.privatePhone,
+        isPhoneShared = userSharePreferences.privatePhone,
+    )
+
     fun copyWithUserSharePreferences(
         shareFieldType: ShareFieldType,
     ): ShareUiState = this.copy(
         userSharePreferences = userSharePreferences.copy(
+            privateEmail = if (shareFieldType is ShareFieldType.PrivateEmail) shareFieldType.checked else userSharePreferences.privateEmail,
+            privatePhone = if (shareFieldType is ShareFieldType.PrivatePhone) shareFieldType.checked else userSharePreferences.privatePhone,
             name = if (shareFieldType is ShareFieldType.Name) shareFieldType.checked else userSharePreferences.name,
             location = if (shareFieldType is ShareFieldType.Location) shareFieldType.checked else userSharePreferences.location,
             title = if (shareFieldType is ShareFieldType.Title) shareFieldType.checked else userSharePreferences.title,
@@ -31,7 +35,7 @@ internal data class ShareUiState(
     )
 }
 
-internal data class PrivateContactInfo(
+internal data class PrivateContactState(
     val emailValue: String = "",
     val isEmailShared: Boolean = false,
     val phoneValue: String = "",
@@ -62,6 +66,14 @@ internal sealed class ShareFieldType {
     ) : ShareFieldType()
 
     data class ProfileUrl(
+        override val checked: Boolean
+    ) : ShareFieldType()
+
+    data class PrivateEmail(
+        override val checked: Boolean
+    ) : ShareFieldType()
+
+    data class PrivatePhone(
         override val checked: Boolean
     ) : ShareFieldType()
 }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/ShareViewModel.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/ShareViewModel.kt
@@ -4,16 +4,21 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gravatar.app.usercomponent.domain.repository.UserRepository
 import com.gravatar.app.usercomponent.domain.usecase.GetAvatarUrl
+import com.gravatar.app.usercomponent.domain.usecase.GetUserSharePreferences
+import com.gravatar.app.usercomponent.domain.usecase.UpdateUserSharePreferences
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 internal class ShareViewModel(
     private val userRepository: UserRepository,
     private val getAvatarUrl: GetAvatarUrl,
+    private val getUserSharePreferences: GetUserSharePreferences,
+    private val updateUserSharePreferences: UpdateUserSharePreferences,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ShareUiState())
@@ -22,6 +27,7 @@ internal class ShareViewModel(
     init {
         collectProfile()
         collectAvatarUrl()
+        collectUserSharePreferences()
     }
 
     fun onEvent(shareEvent: ShareEvent) {
@@ -68,13 +74,18 @@ internal class ShareViewModel(
 
             is ShareEvent.OnAboutAppClicked -> showAboutAppDialog()
             is ShareEvent.OnDismissAboutAppDialog -> hideAboutAppDialog()
-            is ShareEvent.OnUserSharePreferencesChanged -> updateUserSharePreferences(shareEvent.shareFieldType)
+            is ShareEvent.OnUserSharePreferencesChanged -> handleUserSharePreferencesChange(shareEvent.shareFieldType)
         }
     }
 
-    private fun updateUserSharePreferences(shareFieldType: ShareFieldType) {
-        _uiState.update { currentState ->
-            currentState.copyWithUserSharePreferences(shareFieldType)
+    private fun handleUserSharePreferencesChange(shareFieldType: ShareFieldType) {
+        with(_uiState.value.copyWithUserSharePreferences(shareFieldType)) {
+            // update the UI state with the new preferences
+            _uiState.value = this
+            // Save the updated preferences
+            viewModelScope.launch {
+                updateUserSharePreferences(this@with.userSharePreferences)
+            }
         }
     }
 
@@ -108,6 +119,18 @@ internal class ShareViewModel(
                 _uiState.update { currentState ->
                     currentState.copy(
                         profile = profile,
+                    )
+                }
+            }
+            .launchIn(viewModelScope)
+    }
+
+    private fun collectUserSharePreferences() {
+        getUserSharePreferences()
+            .onEach { preferences ->
+                _uiState.update { currentState ->
+                    currentState.copy(
+                        userSharePreferences = preferences
                     )
                 }
             }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/ShareViewModel.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/ShareViewModel.kt
@@ -36,17 +36,7 @@ internal class ShareViewModel(
                 _uiState.update {
                     it.copy(
                         privateContactInfo = it.privateContactInfo.copy(
-                            emailValue = shareEvent.value
-                        )
-                    )
-                }
-            }
-
-            is ShareEvent.OnEmailSharingChanged -> {
-                _uiState.update {
-                    it.copy(
-                        privateContactInfo = it.privateContactInfo.copy(
-                            isEmailShared = shareEvent.isShared
+                            privateEmail = shareEvent.value
                         )
                     )
                 }
@@ -56,17 +46,7 @@ internal class ShareViewModel(
                 _uiState.update {
                     it.copy(
                         privateContactInfo = it.privateContactInfo.copy(
-                            phoneValue = shareEvent.value
-                        )
-                    )
-                }
-            }
-
-            is ShareEvent.OnPhoneSharingChanged -> {
-                _uiState.update {
-                    it.copy(
-                        privateContactInfo = it.privateContactInfo.copy(
-                            isPhoneShared = shareEvent.isShared
+                            privatePhone = shareEvent.value
                         )
                     )
                 }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/components/SharePrivateContactInfo.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/components/SharePrivateContactInfo.kt
@@ -9,11 +9,11 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.gravatar.app.homeUi.R
-import com.gravatar.app.homeUi.presentation.home.share.PrivateContactInfo
+import com.gravatar.app.homeUi.presentation.home.share.PrivateContactState
 
 @Composable
 internal fun SharePrivateContactInfo(
-    privateContactInfo: PrivateContactInfo,
+    privateContactState: PrivateContactState,
     onEmailValueChange: (String) -> Unit,
     onEmailSwitchCheckedChange: (Boolean) -> Unit,
     onPhoneValueChange: (String) -> Unit,
@@ -29,17 +29,17 @@ internal fun SharePrivateContactInfo(
         )
         ShareEditableField(
             placeholder = R.string.share_tab_private_contact_email_placeholder,
-            value = privateContactInfo.emailValue,
+            value = privateContactState.emailValue,
             onValueChange = onEmailValueChange,
-            switchChecked = privateContactInfo.isEmailShared,
+            switchChecked = privateContactState.isEmailShared,
             keyboardType = KeyboardType.Email,
             onSwitchCheckedChange = onEmailSwitchCheckedChange,
         )
         ShareEditableField(
             placeholder = R.string.share_tab_private_contact_phone_number_placeholder,
-            value = privateContactInfo.phoneValue,
+            value = privateContactState.phoneValue,
             onValueChange = onPhoneValueChange,
-            switchChecked = privateContactInfo.isPhoneShared,
+            switchChecked = privateContactState.isPhoneShared,
             keyboardType = KeyboardType.Phone,
             onSwitchCheckedChange = onPhoneSwitchCheckedChange,
         )
@@ -50,7 +50,7 @@ internal fun SharePrivateContactInfo(
 @Composable
 private fun SharePrivateContactInfoPreview() {
     SharePrivateContactInfo(
-        privateContactInfo = PrivateContactInfo(
+        privateContactState = PrivateContactState(
             emailValue = "example@email.com",
             isEmailShared = true,
             phoneValue = "123-456-7890",

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/components/SharePublicContactInfo.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/components/SharePublicContactInfo.kt
@@ -111,14 +111,7 @@ private fun SharePublicContactInfoPreview() {
     GravatarAppTheme {
         SharePublicContactInfo(
             profile = defaultProfile(hash = "hash"),
-            userSharePreferences = UserSharePreferences(
-                name = true,
-                location = true,
-                title = true,
-                organization = true,
-                description = true,
-                profileUrl = true
-            ),
+            userSharePreferences = UserSharePreferences.Default,
             onUserPreferenceChanged = {},
         )
     }

--- a/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/share/ShareViewModelTest.kt
+++ b/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/share/ShareViewModelTest.kt
@@ -2,8 +2,11 @@ package com.gravatar.app.homeUi.presentation.home.share
 
 import app.cash.turbine.test
 import com.gravatar.app.testUtils.CoroutineTestRule
+import com.gravatar.app.usercomponent.domain.model.UserSharePreferences
 import com.gravatar.app.usercomponent.domain.repository.UserRepository
 import com.gravatar.app.usercomponent.domain.usecase.GetAvatarUrl
+import com.gravatar.app.usercomponent.domain.usecase.GetUserSharePreferences
+import com.gravatar.app.usercomponent.domain.usecase.UpdateUserSharePreferences
 import com.gravatar.restapi.models.Profile
 import com.gravatar.restapi.models.ProfileContactInfo
 import io.mockk.every
@@ -32,17 +35,26 @@ class ShareViewModelTest {
     private val getAvatarUrl: GetAvatarUrl = object : GetAvatarUrl {
         override fun invoke() = avatarUrlFlow
     }
+    private val getUserSharePreferences: GetUserSharePreferences = object : GetUserSharePreferences {
+        override fun invoke() = userSharePreferencesFlow
+    }
+    private val updateUserSharePreferences = object : UpdateUserSharePreferences {
+        override suspend fun invoke(userSharePreferences: UserSharePreferences) {
+            userSharePreferencesFlow.emit(userSharePreferences)
+        }
+    }
     private val userRepository = mockk<UserRepository>()
 
     private lateinit var viewModel: ShareViewModel
 
     private val avatarUrlFlow: MutableSharedFlow<URL?> = MutableSharedFlow()
     private val profileFlow: MutableSharedFlow<Profile?> = MutableSharedFlow()
+    private val userSharePreferencesFlow: MutableSharedFlow<UserSharePreferences> = MutableSharedFlow()
 
     @Before
     fun setup() {
         every { userRepository.getProfile() } returns profileFlow
-        viewModel = ShareViewModel(userRepository, getAvatarUrl)
+        viewModel = ShareViewModel(userRepository, getAvatarUrl, getUserSharePreferences, updateUserSharePreferences)
     }
 
     @Test
@@ -295,6 +307,53 @@ class ShareViewModelTest {
             assertEquals(initialState.userSharePreferences.title, updatedState.userSharePreferences.title)
             assertEquals(initialState.userSharePreferences.organization, updatedState.userSharePreferences.organization)
             assertEquals(initialState.userSharePreferences.description, updatedState.userSharePreferences.description)
+        }
+    }
+
+    @Test
+    fun `when user share preferences are emitted then uiState is updated with preferences`() = runTest {
+        // Given
+        val testPreferences = UserSharePreferences(
+            name = false,
+            location = true,
+            title = false,
+            organization = true,
+            description = false,
+            profileUrl = true
+        )
+
+        // When
+        userSharePreferencesFlow.emit(testPreferences)
+        advanceUntilIdle()
+
+        // Then
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertEquals(testPreferences, state.userSharePreferences)
+        }
+    }
+
+    @Test
+    fun `when user share preferences are changed then updateUserSharePreferences is called`() = runTest {
+        // Given
+        val initialState = viewModel.uiState.value
+        val newNamePreference = !initialState.userSharePreferences.name
+        val shareFieldType = ShareFieldType.Name(checked = newNamePreference)
+
+        userSharePreferencesFlow.test {
+            // When
+            viewModel.onEvent(ShareEvent.OnUserSharePreferencesChanged(shareFieldType))
+
+            // Then
+            val expectedSharePreferences = UserSharePreferences(
+                name = newNamePreference,
+                location = initialState.userSharePreferences.location,
+                title = initialState.userSharePreferences.title,
+                organization = initialState.userSharePreferences.organization,
+                description = initialState.userSharePreferences.description,
+                profileUrl = initialState.userSharePreferences.profileUrl
+            )
+            assertEquals(expectedSharePreferences, awaitItem())
         }
     }
 

--- a/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/share/ShareViewModelTest.kt
+++ b/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/share/ShareViewModelTest.kt
@@ -91,21 +91,7 @@ class ShareViewModelTest {
 
         // Then
         viewModel.uiState.test {
-            assertEquals(newEmailValue, awaitItem().privateContactInfo.emailValue)
-        }
-    }
-
-    @Test
-    fun `when OnEmailSharingChanged event is triggered then isEmailShared is updated`() = runTest {
-        // Given
-        val isShared = true
-
-        // When
-        viewModel.onEvent(ShareEvent.OnEmailSharingChanged(isShared))
-
-        // Then
-        viewModel.uiState.test {
-            assertEquals(isShared, awaitItem().privateContactInfo.isEmailShared)
+            assertEquals(newEmailValue, awaitItem().privateContactState.emailValue)
         }
     }
 
@@ -119,21 +105,7 @@ class ShareViewModelTest {
 
         // Then
         viewModel.uiState.test {
-            assertEquals(newPhoneValue, awaitItem().privateContactInfo.phoneValue)
-        }
-    }
-
-    @Test
-    fun `when OnPhoneSharingChanged event is triggered then isPhoneShared is updated`() = runTest {
-        // Given
-        val isShared = true
-
-        // When
-        viewModel.onEvent(ShareEvent.OnPhoneSharingChanged(isShared))
-
-        // Then
-        viewModel.uiState.test {
-            assertEquals(isShared, awaitItem().privateContactInfo.isPhoneShared)
+            assertEquals(newPhoneValue, awaitItem().privateContactState.phoneValue)
         }
     }
 
@@ -313,13 +285,10 @@ class ShareViewModelTest {
     @Test
     fun `when user share preferences are emitted then uiState is updated with preferences`() = runTest {
         // Given
-        val testPreferences = UserSharePreferences(
+        val testPreferences = UserSharePreferences.Default.copy(
             name = false,
-            location = true,
             title = false,
-            organization = true,
             description = false,
-            profileUrl = true
         )
 
         // When
@@ -345,13 +314,8 @@ class ShareViewModelTest {
             viewModel.onEvent(ShareEvent.OnUserSharePreferencesChanged(shareFieldType))
 
             // Then
-            val expectedSharePreferences = UserSharePreferences(
+            val expectedSharePreferences = initialState.userSharePreferences.copy(
                 name = newNamePreference,
-                location = initialState.userSharePreferences.location,
-                title = initialState.userSharePreferences.title,
-                organization = initialState.userSharePreferences.organization,
-                description = initialState.userSharePreferences.description,
-                profileUrl = initialState.userSharePreferences.profileUrl
             )
             assertEquals(expectedSharePreferences, awaitItem())
         }

--- a/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/share/components/SharePrivateContactInfoTest.kt
+++ b/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/share/components/SharePrivateContactInfoTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.gravatar.app.design.theme.GravatarAppTheme
-import com.gravatar.app.homeUi.presentation.home.share.PrivateContactInfo
+import com.gravatar.app.homeUi.presentation.home.share.PrivateContactState
 import com.gravatar.app.testUtils.roborazzi.RoborazziTest
 import org.junit.Test
 
@@ -15,7 +15,7 @@ class SharePrivateContactInfoTest : RoborazziTest() {
     fun sharePrivateContactInfo_bothSwitchesOn() = screenshotTest {
         GravatarAppTheme {
             SharePrivateContactInfo(
-                privateContactInfo = PrivateContactInfo(
+                privateContactState = PrivateContactState(
                     emailValue = "example@email.com",
                     isEmailShared = true,
                     phoneValue = "123-456-7890",
@@ -36,7 +36,7 @@ class SharePrivateContactInfoTest : RoborazziTest() {
     fun sharePrivateContactInfo_bothSwitchesOff() = screenshotTest {
         GravatarAppTheme {
             SharePrivateContactInfo(
-                privateContactInfo = PrivateContactInfo(
+                privateContactState = PrivateContactState(
                     emailValue = "example@email.com",
                     isEmailShared = false,
                     phoneValue = "123-456-7890",
@@ -57,7 +57,7 @@ class SharePrivateContactInfoTest : RoborazziTest() {
     fun sharePrivateContactInfo_emptyValues() = screenshotTest {
         GravatarAppTheme {
             SharePrivateContactInfo(
-                privateContactInfo = PrivateContactInfo(
+                privateContactState = PrivateContactState(
                     emailValue = "",
                     isEmailShared = true,
                     phoneValue = "",

--- a/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/share/components/SharePublicContactInfoTest.kt
+++ b/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/share/components/SharePublicContactInfoTest.kt
@@ -34,14 +34,7 @@ class SharePublicContactInfoTest : RoborazziTest() {
         GravatarAppTheme {
             SharePublicContactInfo(
                 profile = fullProfile,
-                userSharePreferences = UserSharePreferences(
-                    name = true,
-                    location = true,
-                    title = true,
-                    organization = true,
-                    description = true,
-                    profileUrl = true
-                ),
+                userSharePreferences = UserSharePreferences.Default,
                 onUserPreferenceChanged = {},
                 modifier = Modifier.fillMaxWidth()
             )
@@ -59,7 +52,9 @@ class SharePublicContactInfoTest : RoborazziTest() {
                     title = false,
                     organization = false,
                     description = false,
-                    profileUrl = false
+                    profileUrl = false,
+                    privateEmail = false,
+                    privatePhone = false,
                 ),
                 onUserPreferenceChanged = {},
                 modifier = Modifier.fillMaxWidth()
@@ -72,14 +67,7 @@ class SharePublicContactInfoTest : RoborazziTest() {
         GravatarAppTheme {
             SharePublicContactInfo(
                 profile = defaultProfile(hash = "hash"),
-                userSharePreferences = UserSharePreferences(
-                    name = true,
-                    location = true,
-                    title = true,
-                    organization = true,
-                    description = true,
-                    profileUrl = true
-                ),
+                userSharePreferences = UserSharePreferences.Default,
                 onUserPreferenceChanged = {},
                 modifier = Modifier.fillMaxWidth()
             )

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/UserPrefsStorage.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/UserPrefsStorage.kt
@@ -3,10 +3,12 @@ package com.gravatar.app.usercomponent.data
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.IOException
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.gravatar.app.foundations.DispatcherProvider
 import com.gravatar.app.usercomponent.di.UserPrefs
+import com.gravatar.app.usercomponent.domain.model.UserSharePreferences
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.firstOrNull
@@ -29,10 +31,16 @@ internal interface AvatarCacheBusterStorage {
     suspend fun saveAvatarCacheBuster(value: String)
 }
 
+internal interface UserSharePreferencesStorage {
+    fun getUserSharePreferences(): Flow<UserSharePreferences>
+
+    suspend fun saveUserSharePreferences(userSharePreferences: UserSharePreferences)
+}
+
 /**
  * Convenient interface to clear all user related data in one call.
  */
-internal interface UserStorage : AuthTokenStorage, AvatarCacheBusterStorage {
+internal interface UserStorage : AuthTokenStorage, AvatarCacheBusterStorage, UserSharePreferencesStorage {
     suspend fun clear()
 }
 
@@ -44,10 +52,22 @@ internal class DatastoreUserPrefsStorage(
     companion object {
         private const val AUTH_TOKEN_KEY = "auth_token"
         private const val AVATAR_CACHE_BUSTER_KEY = "avatar_cache_buster"
+        private const val USER_SHARE_NAME_KEY = "share_name"
+        private const val USER_SHARE_LOCATION_KEY = "share_location"
+        private const val USER_SHARE_TITLE_KEY = "share_title"
+        private const val USER_SHARE_ORGANIZATION_KEY = "share_organization"
+        private const val USER_SHARE_DESCRIPTION_KEY = "share_description"
+        private const val USER_SHARE_PROFILE_URL_KEY = "share_profile_url"
     }
 
     private val tokenKey = stringPreferencesKey(AUTH_TOKEN_KEY)
     private val avatarCacheBusterKey = stringPreferencesKey(AVATAR_CACHE_BUSTER_KEY)
+    private val userShareNameKey = booleanPreferencesKey(USER_SHARE_NAME_KEY)
+    private val userShareLocationKey = booleanPreferencesKey(USER_SHARE_LOCATION_KEY)
+    private val userShareTitleKey = booleanPreferencesKey(USER_SHARE_TITLE_KEY)
+    private val userShareOrganizationKey = booleanPreferencesKey(USER_SHARE_ORGANIZATION_KEY)
+    private val userShareDescriptionKey = booleanPreferencesKey(USER_SHARE_DESCRIPTION_KEY)
+    private val userShareProfileUrlKey = booleanPreferencesKey(USER_SHARE_PROFILE_URL_KEY)
 
     override suspend fun getToken(): String? {
         return try {
@@ -92,6 +112,35 @@ internal class DatastoreUserPrefsStorage(
     override suspend fun clear() {
         dataStore.edit { preferences ->
             preferences.clear()
+        }
+    }
+
+    override fun getUserSharePreferences(): Flow<UserSharePreferences> {
+        return dataStore.data
+            .map { preferences ->
+                UserSharePreferences(
+                    name = preferences[userShareNameKey] ?: true,
+                    location = preferences[userShareLocationKey] ?: true,
+                    title = preferences[userShareTitleKey] ?: true,
+                    organization = preferences[userShareOrganizationKey] ?: true,
+                    description = preferences[userShareDescriptionKey] ?: true,
+                    profileUrl = preferences[userShareProfileUrlKey] ?: true
+                )
+            }
+            .catch { emit(UserSharePreferences.Default) }
+            .flowOn(dispatcherProvider.io)
+    }
+
+    override suspend fun saveUserSharePreferences(
+        userSharePreferences: UserSharePreferences
+    ): Unit = withContext(dispatcherProvider.io) {
+        dataStore.edit { preferences ->
+            preferences[userShareNameKey] = userSharePreferences.name
+            preferences[userShareLocationKey] = userSharePreferences.location
+            preferences[userShareTitleKey] = userSharePreferences.title
+            preferences[userShareOrganizationKey] = userSharePreferences.organization
+            preferences[userShareDescriptionKey] = userSharePreferences.description
+            preferences[userShareProfileUrlKey] = userSharePreferences.profileUrl
         }
     }
 }

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/UserPrefsStorage.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/data/UserPrefsStorage.kt
@@ -58,6 +58,8 @@ internal class DatastoreUserPrefsStorage(
         private const val USER_SHARE_ORGANIZATION_KEY = "share_organization"
         private const val USER_SHARE_DESCRIPTION_KEY = "share_description"
         private const val USER_SHARE_PROFILE_URL_KEY = "share_profile_url"
+        private const val USER_SHARE_PRIVATE_EMAIL_KEY = "share_private_email"
+        private const val USER_SHARE_PRIVATE_PHONE_KEY = "share_private_phone"
     }
 
     private val tokenKey = stringPreferencesKey(AUTH_TOKEN_KEY)
@@ -68,6 +70,8 @@ internal class DatastoreUserPrefsStorage(
     private val userShareOrganizationKey = booleanPreferencesKey(USER_SHARE_ORGANIZATION_KEY)
     private val userShareDescriptionKey = booleanPreferencesKey(USER_SHARE_DESCRIPTION_KEY)
     private val userShareProfileUrlKey = booleanPreferencesKey(USER_SHARE_PROFILE_URL_KEY)
+    private val userSharePrivateEmailKey = booleanPreferencesKey(USER_SHARE_PRIVATE_EMAIL_KEY)
+    private val userSharePrivatePhoneKey = booleanPreferencesKey(USER_SHARE_PRIVATE_PHONE_KEY)
 
     override suspend fun getToken(): String? {
         return try {
@@ -119,6 +123,8 @@ internal class DatastoreUserPrefsStorage(
         return dataStore.data
             .map { preferences ->
                 UserSharePreferences(
+                    privateEmail = preferences[userSharePrivateEmailKey] ?: true,
+                    privatePhone = preferences[userSharePrivatePhoneKey] ?: true,
                     name = preferences[userShareNameKey] ?: true,
                     location = preferences[userShareLocationKey] ?: true,
                     title = preferences[userShareTitleKey] ?: true,
@@ -135,6 +141,8 @@ internal class DatastoreUserPrefsStorage(
         userSharePreferences: UserSharePreferences
     ): Unit = withContext(dispatcherProvider.io) {
         dataStore.edit { preferences ->
+            preferences[userSharePrivateEmailKey] = userSharePreferences.privateEmail
+            preferences[userSharePrivatePhoneKey] = userSharePreferences.privatePhone
             preferences[userShareNameKey] = userSharePreferences.name
             preferences[userShareLocationKey] = userSharePreferences.location
             preferences[userShareTitleKey] = userSharePreferences.title

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/DatastoreModule.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/DatastoreModule.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.preferencesDataStore
 import com.gravatar.app.usercomponent.data.AuthTokenStorage
 import com.gravatar.app.usercomponent.data.AvatarCacheBusterStorage
 import com.gravatar.app.usercomponent.data.DatastoreUserPrefsStorage
+import com.gravatar.app.usercomponent.data.UserSharePreferencesStorage
 import com.gravatar.app.usercomponent.data.UserStorage
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.annotation.Named
@@ -30,6 +31,12 @@ internal val datastoreModule = module {
         )
     }
     factory<UserStorage> {
+        DatastoreUserPrefsStorage(
+            dataStore = get(qualifier = named<UserPrefs>()),
+            dispatcherProvider = get()
+        )
+    }
+    factory<UserSharePreferencesStorage> {
         DatastoreUserPrefsStorage(
             dataStore = get(qualifier = named<UserPrefs>()),
             dispatcherProvider = get()

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/UserComponentModule.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/UserComponentModule.kt
@@ -13,6 +13,8 @@ import com.gravatar.app.usercomponent.domain.usecase.DeleteUserAvatar
 import com.gravatar.app.usercomponent.domain.usecase.DeleteUserAvatarUseCase
 import com.gravatar.app.usercomponent.domain.usecase.GetAvatarUrl
 import com.gravatar.app.usercomponent.domain.usecase.GetAvatarUrlUseCase
+import com.gravatar.app.usercomponent.domain.usecase.GetUserSharePreferences
+import com.gravatar.app.usercomponent.domain.usecase.GetUserSharePreferencesUseCase
 import com.gravatar.app.usercomponent.domain.usecase.IsUserLoggedIn
 import com.gravatar.app.usercomponent.domain.usecase.IsUserLoggedInUseCase
 import com.gravatar.app.usercomponent.domain.usecase.Login
@@ -21,6 +23,8 @@ import com.gravatar.app.usercomponent.domain.usecase.Logout
 import com.gravatar.app.usercomponent.domain.usecase.LogoutUseCase
 import com.gravatar.app.usercomponent.domain.usecase.SelectAvatarUseCase
 import com.gravatar.app.usercomponent.domain.usecase.SelectUserAvatar
+import com.gravatar.app.usercomponent.domain.usecase.UpdateUserSharePreferences
+import com.gravatar.app.usercomponent.domain.usecase.UpdateUserSharePreferencesUseCase
 import com.gravatar.app.usercomponent.domain.usecase.UploadAvatarUseCase
 import com.gravatar.app.usercomponent.domain.usecase.UploadUserAvatar
 import org.koin.core.module.dsl.bind
@@ -39,6 +43,8 @@ val userComponentModule = module {
     factoryOf(::SelectAvatarUseCase) { bind<SelectUserAvatar>() }
     factoryOf(::DeleteUserAvatarUseCase) { bind<DeleteUserAvatar>() }
     factoryOf(::UploadAvatarUseCase) { bind<UploadUserAvatar>() }
+    factoryOf(::GetUserSharePreferencesUseCase) { bind<GetUserSharePreferences>() }
+    factoryOf(::UpdateUserSharePreferencesUseCase) { bind<UpdateUserSharePreferences>() }
     factoryOf(::WordPressClient)
     singleOf(::InMemoryUserSessionPersistence) { bind<UserSessionPersistence>() }
     includes(httpClientModule)

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/model/PrivateContactInfo.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/model/PrivateContactInfo.kt
@@ -1,0 +1,13 @@
+package com.gravatar.app.usercomponent.domain.model
+
+data class PrivateContactInfo(
+    val privateEmail: String,
+    val privatePhone: String,
+) {
+    companion object {
+        val Default = PrivateContactInfo(
+            privateEmail = "",
+            privatePhone = ""
+        )
+    }
+}

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/model/UserSharePreferences.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/model/UserSharePreferences.kt
@@ -7,4 +7,15 @@ data class UserSharePreferences(
     val organization: Boolean,
     val description: Boolean,
     val profileUrl: Boolean,
-)
+) {
+    companion object {
+        val Default = UserSharePreferences(
+            name = true,
+            location = true,
+            title = true,
+            organization = true,
+            description = true,
+            profileUrl = true
+        )
+    }
+}

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/model/UserSharePreferences.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/model/UserSharePreferences.kt
@@ -1,6 +1,8 @@
 package com.gravatar.app.usercomponent.domain.model
 
 data class UserSharePreferences(
+    val privateEmail: Boolean,
+    val privatePhone: Boolean,
     val name: Boolean,
     val location: Boolean,
     val title: Boolean,
@@ -10,6 +12,8 @@ data class UserSharePreferences(
 ) {
     companion object {
         val Default = UserSharePreferences(
+            privateEmail = true,
+            privatePhone = true,
             name = true,
             location = true,
             title = true,

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/GetUserSharePreferencesUseCase.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/GetUserSharePreferencesUseCase.kt
@@ -1,0 +1,20 @@
+package com.gravatar.app.usercomponent.domain.usecase
+
+import com.gravatar.app.usercomponent.data.UserSharePreferencesStorage
+import com.gravatar.app.usercomponent.domain.model.UserSharePreferences
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+
+internal class GetUserSharePreferencesUseCase(
+    private val userSharePreferencesStorage: UserSharePreferencesStorage
+) : GetUserSharePreferences {
+
+    override fun invoke(): Flow<UserSharePreferences> {
+        return userSharePreferencesStorage.getUserSharePreferences()
+            .distinctUntilChanged()
+    }
+}
+
+interface GetUserSharePreferences {
+    operator fun invoke(): Flow<UserSharePreferences>
+}

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/UpdateUserSharePreferencesUseCase.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/UpdateUserSharePreferencesUseCase.kt
@@ -1,0 +1,17 @@
+package com.gravatar.app.usercomponent.domain.usecase
+
+import com.gravatar.app.usercomponent.data.UserSharePreferencesStorage
+import com.gravatar.app.usercomponent.domain.model.UserSharePreferences
+
+internal class UpdateUserSharePreferencesUseCase(
+    private val userSharePreferencesStorage: UserSharePreferencesStorage
+) : UpdateUserSharePreferences {
+
+    override suspend fun invoke(userSharePreferences: UserSharePreferences) {
+        userSharePreferencesStorage.saveUserSharePreferences(userSharePreferences)
+    }
+}
+
+interface UpdateUserSharePreferences {
+    suspend operator fun invoke(userSharePreferences: UserSharePreferences)
+}


### PR DESCRIPTION
### Description

This PR adds local storage for the `UserSharePreferences`.

Additionally (in the 2nd commit), I've remodeled a bit how the ShareUiState is built with the private contact info and added the private phone/email share prefs to the `UserSharePreferences` as well. The new `PrivateContactInfo` from `:userComponent` should be used in the next PRs to get/update those values. 

### Testing Steps

1. Launch the app
2. Change the share prefs on the share tab
3. Kill the app
4. Reopen the app and confirm the share prefs are restored