### PR TITLE
[Tooling] Add app version setting using `version.properties`

### DIFF
--- a/build-logic/convention/src/main/kotlin/GravatarAndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/GravatarAndroidApplicationConventionPlugin.kt
@@ -25,8 +25,8 @@ class GravatarAndroidApplicationConventionPlugin : Plugin<Project> {
                 defaultConfig.apply {
                     applicationId = APP_ID
                     targetSdk = TARGET_SDK
-                    versionCode = 1
-                    versionName = "1.0"
+                    versionCode = project.property("versionCode") as Int
+                    versionName = project.property("versionName") as String
                 }
                 buildFeatures.buildConfig = true
                 configureBuildTypes()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,8 +17,8 @@ val versionProperties = loadPropertiesFromFile(file("version.properties"))
 
 project.apply {
     extra.apply {
-        set("versionName", versionProperties.getProperty("versionName", "0.1"))
-        set("versionCode", versionProperties.getProperty("versionCode", "1").toInt())
+        set("versionName", versionProperties.getProperty("versionName", null))
+        set("versionCode", versionProperties.getProperty("versionCode", null).toInt())
         set("isCi", System.getenv("CI")?.toBoolean() ?: false)
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
@@ -9,4 +11,25 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.room) apply false
+}
+
+val versionProperties = loadPropertiesFromFile(file("version.properties"))
+
+project.apply {
+    extra.apply {
+        set("versionName", versionProperties.getProperty("versionName", "0.1"))
+        set("versionCode", versionProperties.getProperty("versionCode", "1").toInt())
+        set("isCi", System.getenv("CI")?.toBoolean() ?: false)
+    }
+}
+
+fun loadPropertiesFromFile(inputFile: File): Properties {
+    val properties = Properties()
+    if (!inputFile.exists()) {
+        return properties
+    }
+    inputFile.inputStream().use { stream ->
+        properties.load(stream)
+    }
+    return properties
 }

--- a/version.properties
+++ b/version.properties
@@ -1,0 +1,2 @@
+versionName=0.1
+versionCode=3


### PR DESCRIPTION
Fixes AINFRA-1020

### Description

This PR moves app versioning control to the `version.properties` file so that it can be more easily updated by our automation.