### PR TITLE
[Tooling] Remove GitHub check about Prototype Build

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -97,6 +97,3 @@ steps:
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - "**/build/outputs/apk/**/*"
-    notify:
-      - github_commit_status:
-          context: Prototype Build

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -91,6 +91,7 @@ steps:
     blocked_state: passed
 
   - label: 🏗️ Prototype Build
+    if: build.pull_request.id != null
     depends_on:
       - run-on-demand-prototype-build
     command: .buildkite/commands/prototype-build.sh


### PR DESCRIPTION
### Description

Follow-up on the brief discussion we had [here](https://github.com/Automattic/Gravatar-Android/pull/65#issuecomment-3121221882) about the Prototype Build GitHub check.

@hamorillo mentioned the Prototype would still always show as pending, even if they don't plan running it, which can be confusing.

The main downside of not showing it at all is making it even more "buried", but again it's about making a choice.
We have a few options:
1. Always run the Prototype Build
2. Optionally run the Prototype Build, with the GitHub check about the build showing as pending
3. Optionally run the Prototype Build but with no pending check (looks nicer but we might "forget" about prototype builds?)
4. Optionally run the Prototype Build with no pending check, but show a message (perhaps with a link to Buildkite) using Danger saying that we can run the Prototype Build if we want (with the downside of always having this message in PRs)

I'm leaving the options here and personally have no strong opinions -- I'd be fine with 3 (meaning merging this PR) if the team decides to do so.

### Testing Steps

The Prototype Build GitHub check shouldn't show.