### PR TITLE
Open TermsOfService and PrivacyPolicy in a customTab

### DIFF
--- a/homeUi/build.gradle.kts
+++ b/homeUi/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.navigation)
     implementation(libs.androidx.constraintLayout.compose)
+    implementation(libs.androidx.browser)
     implementation(libs.coil.compose)
     implementation(project.dependencies.platform(libs.koin.bom))
     implementation(libs.koin.core)

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/components/topbar/components/AboutAppDialog.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/components/topbar/components/AboutAppDialog.kt
@@ -2,6 +2,7 @@ package com.gravatar.app.homeUi.presentation.home.components.topbar.components
 
 import android.content.Context
 import android.content.Intent
+import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -125,14 +126,17 @@ private fun Context.sendSupportEmail() {
 
 private fun Context.openSupportPage() = openUrl("https://$SUPPORT_URL")
 
-private fun Context.openTermsOfService() = openUrl(TERMS_OF_SERVICE_URL)
+private fun Context.openTermsOfService() = openUrlInApp(TERMS_OF_SERVICE_URL)
 
-private fun Context.openPrivacyPolicy() = openUrl(PRIVACY_POLICY_URL)
+private fun Context.openPrivacyPolicy() = openUrlInApp(PRIVACY_POLICY_URL)
 
 private fun Context.openUrl(url: String) {
     val intent = Intent(Intent.ACTION_VIEW, url.toUri())
     startActivity(intent)
 }
+
+private fun Context.openUrlInApp(url: String) =
+    CustomTabsIntent.Builder().build().launchUrl(this, url.toUri())
 
 private const val SUPPORT_URL = "support.gravatar.com"
 private const val SUPPORT_EMAIL = "support@gravatar.com"


### PR DESCRIPTION
### Description

`TermOfService` and `PrivacyPolicy` links should be opened in an in-app browser so the user doesn't leave the app context.

https://github.com/user-attachments/assets/d81d7778-7ee4-4cdf-a00b-70d321e32d32

### Testing Steps

- Launch de app
- Open the `About this app` dialog
- Verify `TermOfService` and `PrivacyPolicy` are opened in an in-app browser.
