### PR TITLE
Pull to refresh on avatars grid will now refresh avatars in the header

### DIFF
--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
@@ -7,8 +7,8 @@ import androidx.lifecycle.viewModelScope
 import com.gravatar.app.homeUi.DownloadManagerError
 import com.gravatar.app.homeUi.ImageDownloader
 import com.gravatar.app.homeUi.presentation.FileUtils
-import com.gravatar.app.usercomponent.domain.repository.UserRepository
 import com.gravatar.app.usercomponent.domain.usecase.DeleteUserAvatar
+import com.gravatar.app.usercomponent.domain.usecase.FetchUserAvatars
 import com.gravatar.app.usercomponent.domain.usecase.GetAvatarUrl
 import com.gravatar.app.usercomponent.domain.usecase.SelectUserAvatar
 import com.gravatar.app.usercomponent.domain.usecase.UploadUserAvatar
@@ -30,7 +30,7 @@ internal class GravatarViewModel(
     private val selectUserAvatar: SelectUserAvatar,
     private val deleteUserAvatar: DeleteUserAvatar,
     private val uploadUserAvatar: UploadUserAvatar,
-    private val userRepository: UserRepository,
+    private val fetchUserAvatars: FetchUserAvatars,
     private val fileUtils: FileUtils,
     private val imageDownloader: ImageDownloader,
 ) : ViewModel() {
@@ -224,7 +224,7 @@ internal class GravatarViewModel(
                     isLoading = !isRefreshing || currentState.avatars == null,
                 )
             }
-            userRepository.getAvatars()
+            fetchUserAvatars(isRefreshing)
                 .onSuccess { avatars ->
                     _uiState.update { currentState ->
                         currentState.copy(

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModel.kt
@@ -224,7 +224,7 @@ internal class GravatarViewModel(
                     isLoading = !isRefreshing || currentState.avatars == null,
                 )
             }
-            fetchUserAvatars(isRefreshing)
+            fetchUserAvatars()
                 .onSuccess { avatars ->
                     _uiState.update { currentState ->
                         currentState.copy(

--- a/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
+++ b/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
@@ -65,7 +65,7 @@ class GravatarViewModelTest {
     fun `init should fetch avatars`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
 
         // When
         initViewModel()
@@ -76,21 +76,21 @@ class GravatarViewModelTest {
             assertEquals(GravatarUiState(isLoading = true), awaitItem())
             assertEquals(GravatarUiState(isLoading = false, avatars = avatars), awaitItem())
         }
-        coVerify { fetchUserAvatars(false) }
+        coVerify { fetchUserAvatars() }
     }
 
     @Test
     fun `onEvent Refresh with pullToRefresh true should fetch avatars with isRefreshing true`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
 
         advanceUntilIdle()
 
         // When
         val refreshedAvatars = createAvatars(4)
-        coEvery { fetchUserAvatars(true) } returns Result.success(refreshedAvatars)
+        coEvery { fetchUserAvatars() } returns Result.success(refreshedAvatars)
         viewModel.onEvent(GravatarEvent.Refresh(true))
 
         // Then
@@ -102,22 +102,21 @@ class GravatarViewModelTest {
                 awaitItem()
             )
         }
-        coVerify(exactly = 1) { fetchUserAvatars(false) }
-        coVerify(exactly = 1) { fetchUserAvatars(true) }
+        coVerify(exactly = 2) { fetchUserAvatars() }
     }
 
     @Test
     fun `onEvent Refresh with pullToRefresh false should fetch avatars with isLoading true`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
 
         advanceUntilIdle()
 
         // When
         val refreshedAvatars = createAvatars(4)
-        coEvery { fetchUserAvatars(false) } returns Result.success(refreshedAvatars)
+        coEvery { fetchUserAvatars() } returns Result.success(refreshedAvatars)
         viewModel.onEvent(GravatarEvent.Refresh(false))
 
         // Then
@@ -129,20 +128,20 @@ class GravatarViewModelTest {
                 awaitItem()
             )
         }
-        coVerify(exactly = 2) { fetchUserAvatars(false) }
+        coVerify(exactly = 2) { fetchUserAvatars() }
     }
 
     @Test
     fun `onEvent Refresh with pullToRefresh true and null avatars should fetch avatars with isLoading true`() = runTest {
         // Given
-        coEvery { fetchUserAvatars(false) } returns Result.failure(IllegalStateException(""))
+        coEvery { fetchUserAvatars() } returns Result.failure(IllegalStateException(""))
         initViewModel()
 
         advanceUntilIdle()
 
         // When
         val refreshedAvatars = createAvatars(4)
-        coEvery { fetchUserAvatars(true) } returns Result.success(refreshedAvatars)
+        coEvery { fetchUserAvatars() } returns Result.success(refreshedAvatars)
         viewModel.onEvent(GravatarEvent.Refresh(true))
 
         // Then
@@ -154,14 +153,13 @@ class GravatarViewModelTest {
                 awaitItem()
             )
         }
-        coVerify(exactly = 1) { fetchUserAvatars(false) }
-        coVerify(exactly = 1) { fetchUserAvatars(true) }
+        coVerify(exactly = 2) { fetchUserAvatars() }
     }
 
     @Test
     fun `fetchAvatars should handle failure`() = runTest {
         // Given
-        coEvery { fetchUserAvatars(false) } returns Result.failure(RuntimeException("Test exception"))
+        coEvery { fetchUserAvatars() } returns Result.failure(RuntimeException("Test exception"))
 
         // When
         initViewModel()
@@ -172,14 +170,14 @@ class GravatarViewModelTest {
             assertEquals(GravatarUiState(isLoading = true), awaitItem())
             assertEquals(GravatarUiState(isLoading = false), awaitItem())
         }
-        coVerify { fetchUserAvatars(false) }
+        coVerify { fetchUserAvatars() }
     }
 
     @Test
     fun `onEvent OnAvatarSelected should select avatar successfully`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -209,7 +207,7 @@ class GravatarViewModelTest {
     fun `onEvent OnAvatarSelected shouldn't select the same avatar again`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -238,7 +236,7 @@ class GravatarViewModelTest {
     fun `onEvent OnAvatarSelected should clean the loading state and skip selecting already selected avatar again`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -281,7 +279,7 @@ class GravatarViewModelTest {
     fun `onEvent OnAvatarSelected should handle failure`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -312,7 +310,7 @@ class GravatarViewModelTest {
     fun `onEvent OnLocalImageSelected should send LaunchImageCropper action`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         val mockUri = mockk<Uri>()
         val mockFile = mockk<File>()
         every { fileUtils.createCroppedAvatarFile() } returns mockFile
@@ -335,7 +333,7 @@ class GravatarViewModelTest {
     fun `onEvent OnImageCropped should upload avatar successfully`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -380,7 +378,7 @@ class GravatarViewModelTest {
         runTest {
             // Given
             val avatars = createAvatars()
-            coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+            coEvery { fetchUserAvatars() } returns Result.success(avatars)
             initViewModel()
             advanceUntilIdle()
 
@@ -423,7 +421,7 @@ class GravatarViewModelTest {
     fun `onEvent OnImageCropped should handle failure`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -473,7 +471,7 @@ class GravatarViewModelTest {
     fun `onEvent OnFailedAvatarDialogDismissed should clear failedUploadDialog`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -520,7 +518,7 @@ class GravatarViewModelTest {
     fun `onEvent OnFailedAvatarDismissed should remove failed upload and clear dialog`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -564,7 +562,7 @@ class GravatarViewModelTest {
     fun `onEvent OnFailedAvatarTapped should show failed upload dialog`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -610,7 +608,7 @@ class GravatarViewModelTest {
     fun `onEvent OnDeleteAvatar should delete non-selected avatar successfully`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -636,7 +634,7 @@ class GravatarViewModelTest {
     fun `onEvent OnDeleteAvatar should delete selected avatar successfully and update selectedAvatarId`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -671,7 +669,7 @@ class GravatarViewModelTest {
     fun `onEvent OnDeleteAvatar should handle failure and restore avatar`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -701,7 +699,7 @@ class GravatarViewModelTest {
     fun `onEvent OnDeleteAvatar should handle failure and restore selected avatar`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -736,7 +734,7 @@ class GravatarViewModelTest {
     fun `onEvent OnShowDeleteConfirmation should update confirmAvatarDeletionId`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -761,7 +759,7 @@ class GravatarViewModelTest {
     fun `onEvent OnDismissDeleteConfirmation should clear confirmAvatarDeletionId`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -787,7 +785,7 @@ class GravatarViewModelTest {
     @Test
     fun `each avatar URL collected should be set as state`() = runTest {
         // Given
-        coJustAwait { fetchUserAvatars(false) }
+        coJustAwait { fetchUserAvatars() }
         initViewModel()
         advanceUntilIdle()
 
@@ -805,7 +803,7 @@ class GravatarViewModelTest {
     fun `onEvent OnDownloadAvatar should download avatar image`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -828,7 +826,7 @@ class GravatarViewModelTest {
     fun `onEvent OnDownloadAvatar should handle download manager not available`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -853,7 +851,7 @@ class GravatarViewModelTest {
     fun `onEvent OnDownloadAvatar should handle download manager disabled`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -879,7 +877,7 @@ class GravatarViewModelTest {
     fun `onEvent OnAboutAppClicked should show about app dialog`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -902,7 +900,7 @@ class GravatarViewModelTest {
     fun `onEvent OnDismissAboutAppDialog should hide about app dialog`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
+        coEvery { fetchUserAvatars() } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 

--- a/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
+++ b/homeUi/src/test/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarViewModelTest.kt
@@ -4,11 +4,13 @@ import android.net.Uri
 import androidx.core.net.toFile
 import app.cash.turbine.test
 import com.gravatar.AvatarUrl
+import com.gravatar.app.homeUi.DownloadManagerError
 import com.gravatar.app.homeUi.ImageDownloader
 import com.gravatar.app.homeUi.presentation.FileUtils
 import com.gravatar.app.testUtils.CoroutineTestRule
 import com.gravatar.app.usercomponent.domain.repository.UserRepository
 import com.gravatar.app.usercomponent.domain.usecase.DeleteUserAvatar
+import com.gravatar.app.usercomponent.domain.usecase.FetchUserAvatars
 import com.gravatar.app.usercomponent.domain.usecase.GetAvatarUrl
 import com.gravatar.app.usercomponent.domain.usecase.SelectUserAvatar
 import com.gravatar.app.usercomponent.domain.usecase.UploadUserAvatar
@@ -51,6 +53,7 @@ class GravatarViewModelTest {
     private val selectUserAvatar: SelectUserAvatar = mockk()
     private val deleteUserAvatar: DeleteUserAvatar = mockk()
     private val uploadUserAvatar: UploadUserAvatar = mockk()
+    private val fetchUserAvatars: FetchUserAvatars = mockk()
     private val fileUtils: FileUtils = mockk()
     private val imageDownloader: ImageDownloader = mockk()
     private lateinit var viewModel: GravatarViewModel
@@ -62,7 +65,7 @@ class GravatarViewModelTest {
     fun `init should fetch avatars`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
 
         // When
         initViewModel()
@@ -73,21 +76,21 @@ class GravatarViewModelTest {
             assertEquals(GravatarUiState(isLoading = true), awaitItem())
             assertEquals(GravatarUiState(isLoading = false, avatars = avatars), awaitItem())
         }
-        coVerify { userRepository.getAvatars() }
+        coVerify { fetchUserAvatars(false) }
     }
 
     @Test
     fun `onEvent Refresh with pullToRefresh true should fetch avatars with isRefreshing true`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
 
         advanceUntilIdle()
 
         // When
         val refreshedAvatars = createAvatars(4)
-        coEvery { userRepository.getAvatars() } returns Result.success(refreshedAvatars)
+        coEvery { fetchUserAvatars(true) } returns Result.success(refreshedAvatars)
         viewModel.onEvent(GravatarEvent.Refresh(true))
 
         // Then
@@ -99,21 +102,22 @@ class GravatarViewModelTest {
                 awaitItem()
             )
         }
-        coVerify(exactly = 2) { userRepository.getAvatars() }
+        coVerify(exactly = 1) { fetchUserAvatars(false) }
+        coVerify(exactly = 1) { fetchUserAvatars(true) }
     }
 
     @Test
     fun `onEvent Refresh with pullToRefresh false should fetch avatars with isLoading true`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
 
         advanceUntilIdle()
 
         // When
         val refreshedAvatars = createAvatars(4)
-        coEvery { userRepository.getAvatars() } returns Result.success(refreshedAvatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(refreshedAvatars)
         viewModel.onEvent(GravatarEvent.Refresh(false))
 
         // Then
@@ -125,20 +129,20 @@ class GravatarViewModelTest {
                 awaitItem()
             )
         }
-        coVerify(exactly = 2) { userRepository.getAvatars() }
+        coVerify(exactly = 2) { fetchUserAvatars(false) }
     }
 
     @Test
     fun `onEvent Refresh with pullToRefresh true and null avatars should fetch avatars with isLoading true`() = runTest {
         // Given
-        coEvery { userRepository.getAvatars() } returns Result.failure(IllegalStateException(""))
+        coEvery { fetchUserAvatars(false) } returns Result.failure(IllegalStateException(""))
         initViewModel()
 
         advanceUntilIdle()
 
         // When
         val refreshedAvatars = createAvatars(4)
-        coEvery { userRepository.getAvatars() } returns Result.success(refreshedAvatars)
+        coEvery { fetchUserAvatars(true) } returns Result.success(refreshedAvatars)
         viewModel.onEvent(GravatarEvent.Refresh(true))
 
         // Then
@@ -150,13 +154,14 @@ class GravatarViewModelTest {
                 awaitItem()
             )
         }
-        coVerify(exactly = 2) { userRepository.getAvatars() }
+        coVerify(exactly = 1) { fetchUserAvatars(false) }
+        coVerify(exactly = 1) { fetchUserAvatars(true) }
     }
 
     @Test
     fun `fetchAvatars should handle failure`() = runTest {
         // Given
-        coEvery { userRepository.getAvatars() } returns Result.failure(RuntimeException("Test exception"))
+        coEvery { fetchUserAvatars(false) } returns Result.failure(RuntimeException("Test exception"))
 
         // When
         initViewModel()
@@ -167,14 +172,14 @@ class GravatarViewModelTest {
             assertEquals(GravatarUiState(isLoading = true), awaitItem())
             assertEquals(GravatarUiState(isLoading = false), awaitItem())
         }
-        coVerify { userRepository.getAvatars() }
+        coVerify { fetchUserAvatars(false) }
     }
 
     @Test
     fun `onEvent OnAvatarSelected should select avatar successfully`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -204,7 +209,7 @@ class GravatarViewModelTest {
     fun `onEvent OnAvatarSelected shouldn't select the same avatar again`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -233,7 +238,7 @@ class GravatarViewModelTest {
     fun `onEvent OnAvatarSelected should clean the loading state and skip selecting already selected avatar again`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -276,7 +281,7 @@ class GravatarViewModelTest {
     fun `onEvent OnAvatarSelected should handle failure`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -307,7 +312,7 @@ class GravatarViewModelTest {
     fun `onEvent OnLocalImageSelected should send LaunchImageCropper action`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         val mockUri = mockk<Uri>()
         val mockFile = mockk<File>()
         every { fileUtils.createCroppedAvatarFile() } returns mockFile
@@ -330,7 +335,7 @@ class GravatarViewModelTest {
     fun `onEvent OnImageCropped should upload avatar successfully`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -375,7 +380,7 @@ class GravatarViewModelTest {
         runTest {
             // Given
             val avatars = createAvatars()
-            coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+            coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
             initViewModel()
             advanceUntilIdle()
 
@@ -418,7 +423,7 @@ class GravatarViewModelTest {
     fun `onEvent OnImageCropped should handle failure`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -468,7 +473,7 @@ class GravatarViewModelTest {
     fun `onEvent OnFailedAvatarDialogDismissed should clear failedUploadDialog`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -515,7 +520,7 @@ class GravatarViewModelTest {
     fun `onEvent OnFailedAvatarDismissed should remove failed upload and clear dialog`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -559,7 +564,7 @@ class GravatarViewModelTest {
     fun `onEvent OnFailedAvatarTapped should show failed upload dialog`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -605,7 +610,7 @@ class GravatarViewModelTest {
     fun `onEvent OnDeleteAvatar should delete non-selected avatar successfully`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -631,7 +636,7 @@ class GravatarViewModelTest {
     fun `onEvent OnDeleteAvatar should delete selected avatar successfully and update selectedAvatarId`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -666,7 +671,7 @@ class GravatarViewModelTest {
     fun `onEvent OnDeleteAvatar should handle failure and restore avatar`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -696,7 +701,7 @@ class GravatarViewModelTest {
     fun `onEvent OnDeleteAvatar should handle failure and restore selected avatar`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -731,7 +736,7 @@ class GravatarViewModelTest {
     fun `onEvent OnShowDeleteConfirmation should update confirmAvatarDeletionId`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -756,7 +761,7 @@ class GravatarViewModelTest {
     fun `onEvent OnDismissDeleteConfirmation should clear confirmAvatarDeletionId`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -782,7 +787,7 @@ class GravatarViewModelTest {
     @Test
     fun `each avatar URL collected should be set as state`() = runTest {
         // Given
-        coJustAwait { userRepository.getAvatars() }
+        coJustAwait { fetchUserAvatars(false) }
         initViewModel()
         advanceUntilIdle()
 
@@ -800,7 +805,7 @@ class GravatarViewModelTest {
     fun `onEvent OnDownloadAvatar should download avatar image`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -823,7 +828,7 @@ class GravatarViewModelTest {
     fun `onEvent OnDownloadAvatar should handle download manager not available`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -831,7 +836,7 @@ class GravatarViewModelTest {
         val avatarUrl = avatars.first { it.imageId == avatarId }.imageUrl
         coEvery {
             imageDownloader.downloadImage(avatarUrl)
-        } returns GravatarResult.Failure(com.gravatar.app.homeUi.DownloadManagerError.DOWNLOAD_MANAGER_NOT_AVAILABLE)
+        } returns GravatarResult.Failure(DownloadManagerError.DOWNLOAD_MANAGER_NOT_AVAILABLE)
 
         // When
         viewModel.onEvent(GravatarEvent.OnDownloadAvatar(avatarId))
@@ -848,7 +853,7 @@ class GravatarViewModelTest {
     fun `onEvent OnDownloadAvatar should handle download manager disabled`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -856,7 +861,7 @@ class GravatarViewModelTest {
         val avatarUrl = avatars.first { it.imageId == avatarId }.imageUrl
         coEvery {
             imageDownloader.downloadImage(avatarUrl)
-        } returns GravatarResult.Failure(com.gravatar.app.homeUi.DownloadManagerError.DOWNLOAD_MANAGER_DISABLED)
+        } returns GravatarResult.Failure(DownloadManagerError.DOWNLOAD_MANAGER_DISABLED)
 
         // When
         viewModel.onEvent(GravatarEvent.OnDownloadAvatar(avatarId))
@@ -874,7 +879,7 @@ class GravatarViewModelTest {
     fun `onEvent OnAboutAppClicked should show about app dialog`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -897,7 +902,7 @@ class GravatarViewModelTest {
     fun `onEvent OnDismissAboutAppDialog should hide about app dialog`() = runTest {
         // Given
         val avatars = createAvatars()
-        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { fetchUserAvatars(false) } returns Result.success(avatars)
         initViewModel()
         advanceUntilIdle()
 
@@ -928,7 +933,7 @@ class GravatarViewModelTest {
             selectUserAvatar = selectUserAvatar,
             deleteUserAvatar = deleteUserAvatar,
             uploadUserAvatar = uploadUserAvatar,
-            userRepository = userRepository,
+            fetchUserAvatars = fetchUserAvatars,
             fileUtils = fileUtils,
             imageDownloader = imageDownloader,
         )

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/UserComponentModule.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/di/UserComponentModule.kt
@@ -11,6 +11,8 @@ import com.gravatar.app.usercomponent.domain.repository.ProfileRepository
 import com.gravatar.app.usercomponent.domain.repository.UserRepository
 import com.gravatar.app.usercomponent.domain.usecase.DeleteUserAvatar
 import com.gravatar.app.usercomponent.domain.usecase.DeleteUserAvatarUseCase
+import com.gravatar.app.usercomponent.domain.usecase.FetchAvatarsUseCase
+import com.gravatar.app.usercomponent.domain.usecase.FetchUserAvatars
 import com.gravatar.app.usercomponent.domain.usecase.GetAvatarUrl
 import com.gravatar.app.usercomponent.domain.usecase.GetAvatarUrlUseCase
 import com.gravatar.app.usercomponent.domain.usecase.GetPrivateContactInfo
@@ -46,6 +48,7 @@ val userComponentModule = module {
     factoryOf(::GetAvatarUrlUseCase) { bind<GetAvatarUrl>() }
     factoryOf(::SelectAvatarUseCase) { bind<SelectUserAvatar>() }
     factoryOf(::DeleteUserAvatarUseCase) { bind<DeleteUserAvatar>() }
+    factoryOf(::FetchAvatarsUseCase) { bind<FetchUserAvatars>() }
     factoryOf(::UploadAvatarUseCase) { bind<UploadUserAvatar>() }
     factoryOf(::GetUserSharePreferencesUseCase) { bind<GetUserSharePreferences>() }
     factoryOf(::UpdateUserSharePreferencesUseCase) { bind<UpdateUserSharePreferences>() }

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/FetchAvatarsUseCase.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/FetchAvatarsUseCase.kt
@@ -1,0 +1,27 @@
+package com.gravatar.app.usercomponent.domain.usecase
+
+import com.gravatar.app.usercomponent.data.AvatarCacheBusterStorage
+import com.gravatar.app.usercomponent.domain.repository.UserRepository
+import com.gravatar.restapi.models.Avatar
+
+internal class FetchAvatarsUseCase(
+    private val userRepository: UserRepository,
+    private val avatarCacheBusterStorage: AvatarCacheBusterStorage,
+) : FetchUserAvatars {
+
+    override suspend fun invoke(isRefreshing: Boolean): Result<List<Avatar>> {
+        return userRepository.getAvatars()
+            .onSuccess { avatars ->
+                if (isRefreshing) {
+                    val avatarID = avatars.firstOrNull { it.selected == true }?.imageId
+                    avatarID?.let { id ->
+                        avatarCacheBusterStorage.saveAvatarCacheBuster(id)
+                    }
+                }
+            }
+    }
+}
+
+interface FetchUserAvatars {
+    suspend operator fun invoke(isRefreshing: Boolean): Result<List<Avatar>>
+}

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/FetchAvatarsUseCase.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/FetchAvatarsUseCase.kt
@@ -7,21 +7,20 @@ import com.gravatar.restapi.models.Avatar
 internal class FetchAvatarsUseCase(
     private val userRepository: UserRepository,
     private val avatarCacheBusterStorage: AvatarCacheBusterStorage,
+    private val clock: AppClock,
 ) : FetchUserAvatars {
 
-    override suspend fun invoke(isRefreshing: Boolean): Result<List<Avatar>> {
+    override suspend fun invoke(): Result<List<Avatar>> {
         return userRepository.getAvatars()
             .onSuccess { avatars ->
-                if (isRefreshing) {
-                    val avatarID = avatars.firstOrNull { it.selected == true }?.imageId
-                    avatarID?.let { id ->
-                        avatarCacheBusterStorage.saveAvatarCacheBuster(id)
-                    }
-                }
+                val selectedAvatarId = avatars.firstOrNull { it.selected == true }?.imageId
+                avatarCacheBusterStorage.saveAvatarCacheBuster(
+                    selectedAvatarId ?: clock.now().toString()
+                )
             }
     }
 }
 
 interface FetchUserAvatars {
-    suspend operator fun invoke(isRefreshing: Boolean): Result<List<Avatar>>
+    suspend operator fun invoke(): Result<List<Avatar>>
 }

--- a/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/FetchAvatarsUseCase.kt
+++ b/userComponent/src/main/kotlin/com/gravatar/app/usercomponent/domain/usecase/FetchAvatarsUseCase.kt
@@ -1,5 +1,6 @@
 package com.gravatar.app.usercomponent.domain.usecase
 
+import com.gravatar.app.clock.AppClock
 import com.gravatar.app.usercomponent.data.AvatarCacheBusterStorage
 import com.gravatar.app.usercomponent.domain.repository.UserRepository
 import com.gravatar.restapi.models.Avatar

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/di/UserComponentModuleTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/di/UserComponentModuleTest.kt
@@ -6,6 +6,7 @@ import com.gravatar.app.usercomponent.data.InMemoryUserSessionPersistence
 import com.gravatar.app.usercomponent.data.WordPressClient
 import com.gravatar.app.usercomponent.data.interceptors.UnauthorizeInterceptor
 import com.gravatar.app.usercomponent.domain.usecase.DeleteUserAvatarUseCase
+import com.gravatar.app.usercomponent.domain.usecase.FetchAvatarsUseCase
 import com.gravatar.app.usercomponent.domain.usecase.SelectAvatarUseCase
 import com.gravatar.app.usercomponent.domain.usecase.UploadAvatarUseCase
 import kotlinx.coroutines.CoroutineScope
@@ -28,6 +29,7 @@ class UserComponentModuleTest : KoinTest {
                 definition<SelectAvatarUseCase>(AppClock::class),
                 definition<DeleteUserAvatarUseCase>(AppClock::class),
                 definition<UploadAvatarUseCase>(AppClock::class),
+                definition<FetchAvatarsUseCase>(AppClock::class),
                 definition<UnauthorizeInterceptor>(CoroutineScope::class),
             )
         )

--- a/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/FetchAvatarUseCaseTest.kt
+++ b/userComponent/src/test/kotlin/com/gravatar/app/usercomponent/domain/usecase/FetchAvatarUseCaseTest.kt
@@ -1,0 +1,105 @@
+package com.gravatar.app.usercomponent.domain.usecase
+
+import com.gravatar.app.clock.AppClock
+import com.gravatar.app.testUtils.CoroutineTestRule
+import com.gravatar.app.usercomponent.data.AvatarCacheBusterStorage
+import com.gravatar.app.usercomponent.domain.repository.UserRepository
+import com.gravatar.restapi.models.Avatar
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.net.URI
+
+@ExperimentalCoroutinesApi
+class FetchAvatarUseCaseTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    var coroutineTestRule = CoroutineTestRule(testDispatcher)
+
+    private lateinit var fetchAvatarsUseCase: FetchAvatarsUseCase
+    private val userRepository = mockk<UserRepository>()
+    private val avatarCacheBusterStorage = mockk<AvatarCacheBusterStorage>()
+    private val clock = mockk<AppClock>()
+
+    private val testTimestamp = 1234567890L
+
+    @Before
+    fun setup() {
+        coEvery { clock.now() } returns testTimestamp
+
+        fetchAvatarsUseCase = FetchAvatarsUseCase(
+            userRepository = userRepository,
+            avatarCacheBusterStorage = avatarCacheBusterStorage,
+            clock = clock
+        )
+    }
+
+    @Test
+    fun `invoke should call userRepository getAvatars`() = runTest {
+        // Given
+        val avatars = createAvatars()
+        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { avatarCacheBusterStorage.saveAvatarCacheBuster(any()) } returns Unit
+
+        // When
+        fetchAvatarsUseCase()
+
+        // Then
+        coVerify { userRepository.getAvatars() }
+    }
+
+    @Test
+    fun `invoke should save avatar cache buster and userRepository returns success`() = runTest {
+        // Given
+        val avatars = createAvatars()
+        coEvery { userRepository.getAvatars() } returns Result.success(avatars)
+        coEvery { avatarCacheBusterStorage.saveAvatarCacheBuster(any()) } returns Unit
+
+        // When
+        val result = fetchAvatarsUseCase()
+
+        // Then
+        assert(result.isSuccess)
+        verify { clock.now() }
+        coVerify { avatarCacheBusterStorage.saveAvatarCacheBuster(testTimestamp.toString()) }
+    }
+
+    @Test
+    fun `invoke should not save avatar cache buster when userRepository returns failure`() = runTest {
+        // Given
+        val testException = RuntimeException("Test exception")
+        coEvery { userRepository.getAvatars() } returns Result.failure(testException)
+
+        // When
+        val result = fetchAvatarsUseCase()
+
+        // Then
+        assert(result.isFailure)
+        assert(result.exceptionOrNull() == testException)
+        coVerify(exactly = 0) { avatarCacheBusterStorage.saveAvatarCacheBuster(any()) }
+    }
+
+    private fun createAvatars(count: Int = 3): List<Avatar> {
+        return List(count) { index ->
+            createAvatar(index)
+        }
+    }
+
+    private fun createAvatar(id: Int, isSelected: Boolean = false): Avatar = Avatar {
+        imageUrl = URI.create("https://gravatar.com/avatar/test$id")
+        imageId = id.toString()
+        rating = Avatar.Rating.G
+        altText = "alt$id"
+        updatedDate = ""
+        selected = isSelected
+    }
+}


### PR DESCRIPTION
Closes GRA-640

### Description

If the user has changed their selected avatar in another client, pull to refresh should reflect this change also in the avatars on the header, not just on the grid.

https://github.com/user-attachments/assets/5e1534de-7628-432f-9e9d-bec0b070341a

### Testing Steps

- Run the app
- Go to a different client and change the selected avatar
- On this build, go to the Avatar Picker screen 
- Do a Pull to refresh.
  - Check that the grid has updated selecting the current selected avatar
  - Check that the header has updated showing the current selected avatar
 
