### PR TITLE
Remove "make current" option on selected avatars

### DIFF
--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/components/AvatarMoreOptionsPickerPopup.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/components/AvatarMoreOptionsPickerPopup.kt
@@ -19,14 +19,14 @@ import com.gravatar.ui.GravatarTheme
 
 @Composable
 internal fun AvatarMoreOptionsPickerPopup(
-    isAvatarSelected: Boolean,
+    isSelected: Boolean,
     anchorAlignment: Alignment.Horizontal,
     offset: DpOffset,
     onDismissRequest: () -> Unit,
     onAvatarOptionClicked: (AvatarOption) -> Unit,
 ) {
     val items = buildList {
-        if (!isAvatarSelected) {
+        if (!isSelected) {
             add(
                 PickerPopupItem(
                     text = stringResource(R.string.gravatar_tab_more_options_make_current),
@@ -94,7 +94,7 @@ private fun AvatarMoreOptionsPickerPopupPreview() {
                 .background(MaterialTheme.colorScheme.background),
         ) {
             AvatarMoreOptionsPickerPopup(
-                isAvatarSelected = false,
+                isSelected = false,
                 anchorAlignment = Alignment.Start,
                 offset = DpOffset.Zero,
                 onDismissRequest = {},

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/components/AvatarMoreOptionsPickerPopup.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/components/AvatarMoreOptionsPickerPopup.kt
@@ -19,17 +19,15 @@ import com.gravatar.ui.GravatarTheme
 
 @Composable
 internal fun AvatarMoreOptionsPickerPopup(
+    isAvatarSelected: Boolean,
     anchorAlignment: Alignment.Horizontal,
     offset: DpOffset,
     onDismissRequest: () -> Unit,
     onAvatarOptionClicked: (AvatarOption) -> Unit,
 ) {
-    PickerPopup(
-        anchorAlignment = anchorAlignment,
-        offset = offset,
-        onDismissRequest = onDismissRequest,
-        popupMenu = PickerPopupMenu(
-            items = listOf(
+    val items = buildList {
+        if (!isAvatarSelected) {
+            add(
                 PickerPopupItem(
                     text = stringResource(R.string.gravatar_tab_more_options_make_current),
                     iconRes = R.drawable.check_circle,
@@ -39,29 +37,43 @@ internal fun AvatarMoreOptionsPickerPopup(
                     onClick = {
                         onAvatarOptionClicked(AvatarOption.Select)
                     },
+                )
+            )
+        }
+
+        add(
+            PickerPopupItem(
+                text = stringResource(R.string.gravatar_tab_more_options_download_avatar),
+                iconRes = R.drawable.gravatar_more_options_download,
+                contentDescription = stringResource(
+                    R.string.gravatar_tab_more_options_download_avatar_content_description
                 ),
-                PickerPopupItem(
-                    text = stringResource(R.string.gravatar_tab_more_options_download_avatar),
-                    iconRes = R.drawable.gravatar_more_options_download,
-                    contentDescription = stringResource(
-                        R.string.gravatar_tab_more_options_download_avatar_content_description
-                    ),
-                    onClick = {
-                        onAvatarOptionClicked(AvatarOption.Download)
-                    },
+                onClick = {
+                    onAvatarOptionClicked(AvatarOption.Download)
+                },
+            )
+        )
+
+        add(
+            PickerPopupItem(
+                text = stringResource(R.string.gravatar_tab_more_options_delete_avatar),
+                iconRes = R.drawable.delete_icon,
+                contentDescription = stringResource(
+                    R.string.gravatar_tab_more_options_delete_avatar_content_description
                 ),
-                PickerPopupItem(
-                    text = stringResource(R.string.gravatar_tab_more_options_delete_avatar),
-                    iconRes = R.drawable.delete_icon,
-                    contentDescription = stringResource(
-                        R.string.gravatar_tab_more_options_delete_avatar_content_description
-                    ),
-                    contentColor = MaterialTheme.colorScheme.error,
-                    onClick = {
-                        onAvatarOptionClicked(AvatarOption.Delete)
-                    },
-                ),
-            ),
+                contentColor = MaterialTheme.colorScheme.error,
+                onClick = {
+                    onAvatarOptionClicked(AvatarOption.Delete)
+                },
+            )
+        )
+    }
+    PickerPopup(
+        anchorAlignment = anchorAlignment,
+        offset = offset,
+        onDismissRequest = onDismissRequest,
+        popupMenu = PickerPopupMenu(
+            items = items
         ),
     )
 }
@@ -82,6 +94,7 @@ private fun AvatarMoreOptionsPickerPopupPreview() {
                 .background(MaterialTheme.colorScheme.background),
         ) {
             AvatarMoreOptionsPickerPopup(
+                isAvatarSelected = false,
                 anchorAlignment = Alignment.Start,
                 offset = DpOffset.Zero,
                 onDismissRequest = {},

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/components/SelectableAvatar.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/components/SelectableAvatar.kt
@@ -123,7 +123,7 @@ private fun SelectableAvatar(
         }
         if (moreOptionsPopupVisible) {
             AvatarMoreOptionsPickerPopup(
-                isAvatarSelected = isSelected,
+                isSelected = isSelected,
                 anchorAlignment = Alignment.Start,
                 offset = DpOffset(0.dp, 10.dp),
                 onDismissRequest = { moreOptionsPopupVisible = false },

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/components/SelectableAvatar.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/components/SelectableAvatar.kt
@@ -123,6 +123,7 @@ private fun SelectableAvatar(
         }
         if (moreOptionsPopupVisible) {
             AvatarMoreOptionsPickerPopup(
+                isAvatarSelected = isSelected,
                 anchorAlignment = Alignment.Start,
                 offset = DpOffset(0.dp, 10.dp),
                 onDismissRequest = { moreOptionsPopupVisible = false },


### PR DESCRIPTION
Closes GRA-642

### Description

This PR removes the "Make current" option on the already selected avatar.

<img width="40%" alt="CleanShot 2025-07-30 at 19 45 48@2x" src="https://github.com/user-attachments/assets/76b11a75-ee79-48a7-8fc3-4d1a56459cd7" />
<img width="40%" alt="CleanShot 2025-07-30 at 19 46 06@2x" src="https://github.com/user-attachments/assets/42cfda13-0600-4bee-a8df-56d39851b6a1" />


### Testing Steps

- Tap on a non-selected avatar
  - Check that the "make current" option is there
- Tap on the currently selected avatar
  - Check that the "make current" option is not there   
