### PR TITLE
Revert the reversion of #87

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -91,12 +91,10 @@ steps:
     blocked_state: passed
 
   - label: 🏗️ Prototype Build
+    if: build.pull_request.id != null
     depends_on:
       - run-on-demand-prototype-build
     command: .buildkite/commands/prototype-build.sh
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - "**/build/outputs/apk/**/*"
-    notify:
-      - github_commit_status:
-          context: Prototype Build


### PR DESCRIPTION
### Description

The PR #99 wrongly reverted #87.

#87 was removing purely the **cosmetic GitHub check**, which at request of @hamorillo we've removed based on [this discussion](https://github.com/Automattic/Gravatar-Android/pull/65#issuecomment-3109269033), but the **on-demand prototypes were still available from Buildkite**.
Part of this PR is actually important as it only allows for a PR prototype when you have a PR, otherwise the check will fail.


### Testing Steps
The check shouldn't show and the prototype build should still be able to be triggered normally via Buildkite.