### PR TITLE
[Tooling] Add automation lane to fetch translations

### DIFF
--- a/app/lint.xml
+++ b/app/lint.xml
@@ -2,4 +2,5 @@
 <lint>
     <issue id="GradleDependency" severity="ignore"/>
     <issue id="AndroidGradlePluginVersion" severity="ignore" />
+    <issue id="ExtraTranslation" severity="ignore" />
 </lint>

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -3,4 +3,5 @@
     <issue id="GradleDependency" severity="ignore"/>
     <issue id="AndroidGradlePluginVersion" severity="ignore" />
     <issue id="ExtraTranslation" severity="ignore" />
+    <issue id="MissingTranslation" severity="ignore" />
 </lint>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -27,6 +27,31 @@ BUILD_CODE_FORMATTER = Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCode
 PROTOTYPE_BUILD_DOMAIN = 'https://cdn.a8c-ci.services'
 RELEASE_BUILD_TYPE = 'Release'
 
+GLOTPRESS_PROJECT_BASE_URL = 'https://translate.wordpress.com/projects/gravatar/gravatar-android'
+RESOURCES_TO_TRANSLATE = {
+  File.join('homeUi', 'src', 'main', 'res') => "#{GLOTPRESS_PROJECT_BASE_URL}/login-ui/",
+  File.join('loginUi', 'src', 'main', 'res') => "#{GLOTPRESS_PROJECT_BASE_URL}/home-ui/"
+}.freeze
+
+SUPPORTED_LOCALES = [
+  { glotpress: 'ar',    android: 'ar'     },
+  { glotpress: 'de',    android: 'de'     },
+  { glotpress: 'es',    android: 'es'     },
+  { glotpress: 'fr',    android: 'fr'     },
+  { glotpress: 'he',    android: 'iw'     },
+  { glotpress: 'id',    android: 'in'     },
+  { glotpress: 'it',    android: 'it'     },
+  { glotpress: 'ja',    android: 'ja'     },
+  { glotpress: 'ko',    android: 'ko'     },
+  { glotpress: 'nl',    android: 'nl'     },
+  { glotpress: 'pt-br', android: 'pt-rBR' },
+  { glotpress: 'ru',    android: 'ru'     },
+  { glotpress: 'sv',    android: 'sv'     },
+  { glotpress: 'tr',    android: 'tr'     },
+  { glotpress: 'zh-cn', android: 'zh-rCN' },
+  { glotpress: 'zh-tw', android: 'zh-rTW' }
+].freeze
+
 platform :android do
   # Builds a release app bundle (.aab) for the Gravatar Android app
   #
@@ -134,6 +159,34 @@ platform :android do
     # TODO: using `internal` track with `draft` releases by default while the release itself is in draft mode
     build_bundle
     upload_to_store(track: track, release_status: release_status, rollout: release_status == 'draft' ? nil : '1')
+  end
+
+  # Download the latest app translations from GlotPress and update the strings.xml files accordingly.
+  #
+  # @example Running the lane
+  #          bundle exec fastlane download_translations skip_commit:true
+  #
+  # @param skip_commit [Boolean] Skip committing the changes to git (default: false)
+  #
+  lane :download_translations do |skip_commit: false|
+    RESOURCES_TO_TRANSLATE.each do |res_dir, gp_url|
+      android_download_translations(
+        res_dir: res_dir.to_s,
+        glotpress_url: gp_url,
+        locales: SUPPORTED_LOCALES,
+        skip_commit: true
+      )
+    end
+
+    next if skip_commit
+
+    strings_paths = RESOURCES_TO_TRANSLATE.keys.map(&:to_s)
+    git_add(path: strings_paths)
+    git_commit(
+      path: strings_paths,
+      message: 'Update translations',
+      allow_nothing_to_commit: true
+    )
   end
 
   #####################################################################################

--- a/homeUi/src/main/res/values-ar/strings.xml
+++ b/homeUi/src/main/res/values-ar/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;
+Generator: GlotPress/2.4.0-alpha
+Language: ar
+-->
+<resources>
+</resources>

--- a/homeUi/src/main/res/values-de/strings.xml
+++ b/homeUi/src/main/res/values-de/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=2; plural=n != 1;
+Generator: GlotPress/2.4.0-alpha
+Language: de
+-->
+<resources>
+</resources>

--- a/homeUi/src/main/res/values-es/strings.xml
+++ b/homeUi/src/main/res/values-es/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=2; plural=n != 1;
+Generator: GlotPress/2.4.0-alpha
+Language: es
+-->
+<resources>
+</resources>

--- a/homeUi/src/main/res/values-fr/strings.xml
+++ b/homeUi/src/main/res/values-fr/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=2; plural=n > 1;
+Generator: GlotPress/2.4.0-alpha
+Language: fr
+-->
+<resources>
+</resources>

--- a/homeUi/src/main/res/values-in/strings.xml
+++ b/homeUi/src/main/res/values-in/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=2; plural=n > 1;
+Generator: GlotPress/2.4.0-alpha
+Language: id
+-->
+<resources>
+</resources>

--- a/homeUi/src/main/res/values-it/strings.xml
+++ b/homeUi/src/main/res/values-it/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=2; plural=n != 1;
+Generator: GlotPress/2.4.0-alpha
+Language: it
+-->
+<resources>
+</resources>

--- a/homeUi/src/main/res/values-iw/strings.xml
+++ b/homeUi/src/main/res/values-iw/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=2; plural=n != 1;
+Generator: GlotPress/2.4.0-alpha
+Language: he_IL
+-->
+<resources>
+</resources>

--- a/homeUi/src/main/res/values-ja/strings.xml
+++ b/homeUi/src/main/res/values-ja/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=1; plural=0;
+Generator: GlotPress/2.4.0-alpha
+Language: ja_JP
+-->
+<resources>
+</resources>

--- a/homeUi/src/main/res/values-ko/strings.xml
+++ b/homeUi/src/main/res/values-ko/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=1; plural=0;
+Generator: GlotPress/2.4.0-alpha
+Language: ko_KR
+-->
+<resources>
+</resources>

--- a/homeUi/src/main/res/values-nl/strings.xml
+++ b/homeUi/src/main/res/values-nl/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=2; plural=n != 1;
+Generator: GlotPress/2.4.0-alpha
+Language: nl
+-->
+<resources>
+</resources>

--- a/homeUi/src/main/res/values-pt-rBR/strings.xml
+++ b/homeUi/src/main/res/values-pt-rBR/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=2; plural=(n > 1);
+Generator: GlotPress/2.4.0-alpha
+Language: pt_BR
+-->
+<resources>
+</resources>

--- a/homeUi/src/main/res/values-ru/strings.xml
+++ b/homeUi/src/main/res/values-ru/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);
+Generator: GlotPress/2.4.0-alpha
+Language: ru
+-->
+<resources>
+</resources>

--- a/homeUi/src/main/res/values-sv/strings.xml
+++ b/homeUi/src/main/res/values-sv/strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: 2025-07-29 15:31:37+0000
+Plural-Forms: nplurals=2; plural=n != 1;
+Generator: GlotPress/2.4.0-alpha
+Language: sv_SE
+-->
+<resources>
+    <string name="login_authorization_denied_title">Du måste logga in på Gravatar.com</string>
+    <string name="login_profile_load_failure_alternative_cta">Prova med ett annat konto</string>
+    <string name="login_profile_load_failure_cta">Försök igen</string>
+    <string name="login_profile_load_failure_generic_message">Det var ett problem att ladda in din profil.</string>
+    <string name="login_profile_load_failure_title">Kan inte ladda din profil</string>
+    <string name="login_retrieving_token_failure_message">Något gick fel</string>
+    <string name="log_in">Logga in</string>
+    <string name="your_globally_recognized_avatar">Din globalt igenkända profilbild.</string>
+</resources>

--- a/homeUi/src/main/res/values-tr/strings.xml
+++ b/homeUi/src/main/res/values-tr/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=2; plural=(n > 1);
+Generator: GlotPress/2.4.0-alpha
+Language: tr
+-->
+<resources>
+</resources>

--- a/homeUi/src/main/res/values-zh-rCN/strings.xml
+++ b/homeUi/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=1; plural=0;
+Generator: GlotPress/2.4.0-alpha
+Language: zh_CN
+-->
+<resources>
+</resources>

--- a/homeUi/src/main/res/values-zh-rTW/strings.xml
+++ b/homeUi/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=1; plural=0;
+Generator: GlotPress/2.4.0-alpha
+Language: zh_TW
+-->
+<resources>
+</resources>

--- a/homeUi/src/main/res/values/available_languages.xml
+++ b/homeUi/src/main/res/values/available_languages.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Warning: Auto-generated file, do not edit.-->
+<resources xmlns:tools="http://schemas.android.com/tools">
+  <string-array name="available_languages" translatable="false" tools:ignore="InconsistentArrays">
+    <item>en_US</item>
+    <item>ar</item>
+    <item>de</item>
+    <item>es</item>
+    <item>fr</item>
+    <item>iw</item>
+    <item>in</item>
+    <item>it</item>
+    <item>ja</item>
+    <item>ko</item>
+    <item>nl</item>
+    <item>pt_BR</item>
+    <item>ru</item>
+    <item>sv</item>
+    <item>tr</item>
+    <item>zh_CN</item>
+    <item>zh_TW</item>
+  </string-array>
+</resources>

--- a/loginUi/src/main/res/values-ar/strings.xml
+++ b/loginUi/src/main/res/values-ar/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;
+Generator: GlotPress/2.4.0-alpha
+Language: ar
+-->
+<resources>
+</resources>

--- a/loginUi/src/main/res/values-de/strings.xml
+++ b/loginUi/src/main/res/values-de/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=2; plural=n != 1;
+Generator: GlotPress/2.4.0-alpha
+Language: de
+-->
+<resources>
+</resources>

--- a/loginUi/src/main/res/values-es/strings.xml
+++ b/loginUi/src/main/res/values-es/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=2; plural=n != 1;
+Generator: GlotPress/2.4.0-alpha
+Language: es
+-->
+<resources>
+</resources>

--- a/loginUi/src/main/res/values-fr/strings.xml
+++ b/loginUi/src/main/res/values-fr/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=2; plural=n > 1;
+Generator: GlotPress/2.4.0-alpha
+Language: fr
+-->
+<resources>
+</resources>

--- a/loginUi/src/main/res/values-in/strings.xml
+++ b/loginUi/src/main/res/values-in/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=2; plural=n > 1;
+Generator: GlotPress/2.4.0-alpha
+Language: id
+-->
+<resources>
+</resources>

--- a/loginUi/src/main/res/values-it/strings.xml
+++ b/loginUi/src/main/res/values-it/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=2; plural=n != 1;
+Generator: GlotPress/2.4.0-alpha
+Language: it
+-->
+<resources>
+</resources>

--- a/loginUi/src/main/res/values-iw/strings.xml
+++ b/loginUi/src/main/res/values-iw/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=2; plural=n != 1;
+Generator: GlotPress/2.4.0-alpha
+Language: he_IL
+-->
+<resources>
+</resources>

--- a/loginUi/src/main/res/values-ja/strings.xml
+++ b/loginUi/src/main/res/values-ja/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=1; plural=0;
+Generator: GlotPress/2.4.0-alpha
+Language: ja_JP
+-->
+<resources>
+</resources>

--- a/loginUi/src/main/res/values-ko/strings.xml
+++ b/loginUi/src/main/res/values-ko/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=1; plural=0;
+Generator: GlotPress/2.4.0-alpha
+Language: ko_KR
+-->
+<resources>
+</resources>

--- a/loginUi/src/main/res/values-nl/strings.xml
+++ b/loginUi/src/main/res/values-nl/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=2; plural=n != 1;
+Generator: GlotPress/2.4.0-alpha
+Language: nl
+-->
+<resources>
+</resources>

--- a/loginUi/src/main/res/values-pt-rBR/strings.xml
+++ b/loginUi/src/main/res/values-pt-rBR/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=2; plural=(n > 1);
+Generator: GlotPress/2.4.0-alpha
+Language: pt_BR
+-->
+<resources>
+</resources>

--- a/loginUi/src/main/res/values-ru/strings.xml
+++ b/loginUi/src/main/res/values-ru/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);
+Generator: GlotPress/2.4.0-alpha
+Language: ru
+-->
+<resources>
+</resources>

--- a/loginUi/src/main/res/values-sv/strings.xml
+++ b/loginUi/src/main/res/values-sv/strings.xml
@@ -23,8 +23,6 @@ Language: sv_SE
     <string name="share_tab_private_contact_info_title">Dela privat kontaktinformation</string>
     <string name="share_tab_scan_qr_code">Låt andra skanna denna QR-kod för att dela din kontaktinformation.</string>
     <string name="home_no_internet_available">Ingen internetanslutning</string>
-    <string name="gravatar_tab_no_avatar_selected_info">Ingen profilbild vald. Visar standardprofilbilden.</string>
-    <string name="gravatar_tab_unable_to_load_avatars_message">Det var ett problem att ladda in dina profilbilder. Försök igen om några minuter.</string>
     <string name="gravatar_tab_unable_to_load_avatars">Kan inte ladda profilbilder</string>
     <string name="retry_cta">Försök igen</string>
     <string name="permission_required_dismiss">Avfärda</string>
@@ -83,4 +81,6 @@ Language: sv_SE
     <string name="home_screen_navigation_item_profile">Profil</string>
     <string name="home_screen_navigation_item_share">Dela</string>
     <string name="home_screen_navigation_item_gravatar">Gravatar</string>
+    <string name="gravatar_tab_unable_to_load_avatars_message">Det var ett problem att ladda in dina profilbilder. Försök igen om några minuter.</string>
+    <string name="gravatar_tab_no_avatar_selected_info">Ingen profilbild vald. Visar standardprofilbilden.</string>
 </resources>

--- a/loginUi/src/main/res/values-sv/strings.xml
+++ b/loginUi/src/main/res/values-sv/strings.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: 2025-07-29 21:27:31+0000
+Plural-Forms: nplurals=2; plural=n != 1;
+Generator: GlotPress/2.4.0-alpha
+Language: sv_SE
+-->
+<resources>
+    <string name="private_info_dialog_title">Privat information</string>
+    <string name="private_info_dialog_message">Din e-post och ditt telefonnummer delas endast med hjälp av QR-koden. Denna information är inte sparad i din Gravatar-profil och är inte offentligt tillgänglig.</string>
+    <string name="private_info_button_cta">Jag förstår</string>
+    <string name="share_tab_profile_url_label">Profil-URL</string>
+    <string name="share_tab_name_label">Namn</string>
+    <string name="share_tab_public_info_title">Dela information från din Gravatar-profil.</string>
+    <string name="done_button_cta">Klar</string>
+    <string name="about_app_dialog_privacy_policy">Integritetspolicy</string>
+    <string name="about_app_dialog_terms_of_service">Användarvillkor</string>
+    <string name="about_app_dialog_legal">Juridiskt</string>
+    <string name="about_app_dialog_get_help">Skaffa hjälp</string>
+    <string name="about_app_dialog_about_gravatar">Om Gravatar</string>
+    <string name="share_tab_private_contact_phone_number_placeholder">Telefonnummer</string>
+    <string name="share_tab_private_contact_email_placeholder">E-post</string>
+    <string name="share_tab_private_contact_info_title">Dela privat kontaktinformation</string>
+    <string name="share_tab_scan_qr_code">Låt andra skanna denna QR-kod för att dela din kontaktinformation.</string>
+    <string name="home_no_internet_available">Ingen internetanslutning</string>
+    <string name="gravatar_tab_no_avatar_selected_info">Ingen profilbild vald. Visar standardprofilbilden.</string>
+    <string name="gravatar_tab_unable_to_load_avatars_message">Det var ett problem att ladda in dina profilbilder. Försök igen om några minuter.</string>
+    <string name="gravatar_tab_unable_to_load_avatars">Kan inte ladda profilbilder</string>
+    <string name="retry_cta">Försök igen</string>
+    <string name="permission_required_dismiss">Avfärda</string>
+    <string name="permission_required_open_settings">Öppna inställningar</string>
+    <string name="permission_required_alert_title">Behörighet krävs</string>
+    <string name="gravatar_tab_topbar_menu_about">Om denna app</string>
+    <string name="gravatar_tab_topbar_menu_sign_out">Logga ut</string>
+    <string name="gravatar_tab_topbar_menu_share">Dela</string>
+    <string name="gravatar_tab_topbar_menu_visit_profile">Besök din profil</string>
+    <string name="gravatar_tab_avatar_deletion_failed">Kunde inte ta bort bilden. Försök igen.</string>
+    <string name="gravatar_tab_avatar_selection_failed">Kan inte ändra din profilbild. Försök igen.</string>
+    <string name="gravatar_tab_avatar_updated_successfully">Profilbild uppdaterad.</string>
+    <string name="gravatar_tab_delete_confirmation_cancel">Avbryt</string>
+    <string name="gravatar_tab_delete_confirmation_confirm">Ta bort</string>
+    <string name="gravatar_tab_delete_confirmation_message">Är du säker på att du vill ta bort denna bild?</string>
+    <string name="gravatar_tab_delete_confirmation_title">Ta bort bild</string>
+    <string name="gravatar_tab_more_options_download_avatar_content_description">Ladda ner bild</string>
+    <string name="gravatar_tab_more_options_download_avatar">Ladda ner bild</string>
+    <string name="gravatar_tab_more_options_delete_avatar_content_description">Ta bort denna profilbild</string>
+    <string name="gravatar_tab_more_options_delete_avatar">Ta bort</string>
+    <string name="gravatar_tab_more_options_make_current_content_description">Välj profilbild som nuvarande</string>
+    <string name="gravatar_tab_more_options_make_current">Gör nuvarande</string>
+    <string name="gravatar_tab_avatar_upload_failure_dialog_remove_upload">Ta bort uppladdning</string>
+    <string name="gravatar_tab_avatar_upload_error_action">Försök igen</string>
+    <string name="gravatar_tab_avatar_upload_failure_image_too_big">Den angivna bilden överskrider den maximala storleken: 10 MB</string>
+    <string name="gravatar_tab_avatar_upload_failure_dialog_title">Kunde inte ladda upp bild</string>
+    <string name="gravatar_tab_failed_to_load_avatar_content_description">Uppladdning misslyckades, tryck för att se åtgärder.</string>
+    <string name="gravatar_tab_photos_content_description">Lägg till nytt profilbild från foton</string>
+    <string name="gravatar_tab_photos">Foton</string>
+    <string name="gravatar_tab_camera_content_description">Ta ny profilbild med kamera</string>
+    <string name="gravatar_tab_camera">Kamera</string>
+    <string name="gravatar_tab_upload_avatar_message">Låt din personlighet glänsa med en ny profilbild.</string>
+    <string name="profile_screen_saved_successfully">Profil sparad.</string>
+    <string name="profile_screen_save_fail_try_again">Kan inte spara din profil. Försök igen.</string>
+    <string name="profile_screen_saving">Sparar …</string>
+    <string name="profile_screen_cancel_button">Avbryt</string>
+    <string name="profile_screen_save_button">Spara</string>
+    <string name="picker_submenu_icon_description">Expandera</string>
+    <string name="gravatar_tab_header_more_options">Fler alternativ</string>
+    <string name="gravatar_tab_tap_for_options">Tryck för alternativ</string>
+    <string name="gravatar_tab_empty_avatars">Dina profilbilder kommer visas här</string>
+    <string name="gravatar_tab_previous_avatars">Tidigare profilbilder</string>
+    <string name="about_field_label_contact_email">E-post</string>
+    <string name="about_field_label_cell_phone">Telefon</string>
+    <string name="about_field_label_location">Plats</string>
+    <string name="about_field_description_about_me">Kort beskrivning av din profil</string>
+    <string name="about_field_label_about_me">Om mig</string>
+    <string name="about_field_label_company">Organisation</string>
+    <string name="about_field_label_job_title">Titel</string>
+    <string name="about_field_label_pronouns">Pronomen</string>
+    <string name="about_field_description_pronunciation">Hur man säger ditt namn</string>
+    <string name="about_field_label_pronunciation">Uttal</string>
+    <string name="about_field_label_display_name">Visningsnamn</string>
+    <string name="about_field_label_last_name">Efter</string>
+    <string name="about_field_label_first_name">För</string>
+    <string name="home_screen_navigation_item_profile">Profil</string>
+    <string name="home_screen_navigation_item_share">Dela</string>
+    <string name="home_screen_navigation_item_gravatar">Gravatar</string>
+</resources>

--- a/loginUi/src/main/res/values-tr/strings.xml
+++ b/loginUi/src/main/res/values-tr/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=2; plural=(n > 1);
+Generator: GlotPress/2.4.0-alpha
+Language: tr
+-->
+<resources>
+</resources>

--- a/loginUi/src/main/res/values-zh-rCN/strings.xml
+++ b/loginUi/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=1; plural=0;
+Generator: GlotPress/2.4.0-alpha
+Language: zh_CN
+-->
+<resources>
+</resources>

--- a/loginUi/src/main/res/values-zh-rTW/strings.xml
+++ b/loginUi/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Translation-Revision-Date: +0000
+Plural-Forms: nplurals=1; plural=0;
+Generator: GlotPress/2.4.0-alpha
+Language: zh_TW
+-->
+<resources>
+</resources>

--- a/loginUi/src/main/res/values/available_languages.xml
+++ b/loginUi/src/main/res/values/available_languages.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Warning: Auto-generated file, do not edit.-->
+<resources xmlns:tools="http://schemas.android.com/tools">
+  <string-array name="available_languages" translatable="false" tools:ignore="InconsistentArrays">
+    <item>en_US</item>
+    <item>ar</item>
+    <item>de</item>
+    <item>es</item>
+    <item>fr</item>
+    <item>iw</item>
+    <item>in</item>
+    <item>it</item>
+    <item>ja</item>
+    <item>ko</item>
+    <item>nl</item>
+    <item>pt_BR</item>
+    <item>ru</item>
+    <item>sv</item>
+    <item>tr</item>
+    <item>zh_CN</item>
+    <item>zh_TW</item>
+  </string-array>
+</resources>


### PR DESCRIPTION
Fixes AINFRA-1033

### Description

This PR adds the lane `download_translations` that will fetch the translations from the Gravatar Android GlotPress projects ([login-ui](https://translate.wordpress.com/projects/gravatar/gravatar-android/login-ui/) and [home-ui](https://translate.wordpress.com/projects/gravatar/gravatar-android/home-ui/)) and add them to the project.

I've also ran the lane for the first time to initially add the files (though I noticed the only language with actual translations was Swedish).

### Testing Steps

1. Checkout this branch
2. Add translations to one of the GlotPress projects mentioned above
3. Run `bundle exec download_translations skip_commit:true`
4. Verify that the added translation has been correctly downloaded to the project.