### PR TITLE
Fix issues in the release build related to Navigation Component

### DIFF
--- a/app/src/main/java/com/gravatar/app/navigation/RootNavigation.kt
+++ b/app/src/main/java/com/gravatar/app/navigation/RootNavigation.kt
@@ -1,6 +1,5 @@
 package com.gravatar.app.navigation
 
-import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -31,7 +30,6 @@ fun RootNavigation() {
                 val lastRoute =
                     backStackEntry?.destination?.rootDestination ?: RootDestination.Splash
 
-                Log.d("RootNavigation", "Last route: $lastRoute")
                 when (userSession) {
                     LOGGED_IN -> navController.navigateToRootDestination(
                         destination = RootDestination.Home,

--- a/app/src/main/java/com/gravatar/app/navigation/RootNavigation.kt
+++ b/app/src/main/java/com/gravatar/app/navigation/RootNavigation.kt
@@ -1,7 +1,11 @@
 package com.gravatar.app.navigation
 
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.navigation.NavDestination
+import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -18,20 +22,16 @@ import org.koin.compose.koinInject
 @Composable
 fun RootNavigation() {
     val navController = rememberNavController()
-    val backStackEntry = navController.currentBackStackEntryAsState()
+    val backStackEntry by navController.currentBackStackEntryAsState()
     val isUserLoggedIn: IsUserLoggedIn = koinInject<IsUserLoggedIn>()
 
     LaunchedEffect(Unit) {
         isUserLoggedIn()
             .collect { userSession ->
-                val lastRoute = backStackEntry.value?.destination?.route?.let {
-                    RootDestination.fromRoute(it)
-                } ?: RootDestination.Splash
+                val lastRoute =
+                    backStackEntry?.destination?.rootDestination ?: RootDestination.Splash
 
-                val currentRoute = navController.currentDestination?.route?.let {
-                    RootDestination.fromRoute(it)
-                }
-
+                Log.d("RootNavigation", "Last route: $lastRoute")
                 when (userSession) {
                     LOGGED_IN -> navController.navigateToRootDestination(
                         destination = RootDestination.Home,
@@ -65,11 +65,7 @@ private fun NavHostController.navigateToRootDestination(
     popTo: RootDestination,
     shouldSaveState: Boolean = true
 ) {
-    val currentRoute = currentDestination?.route?.let {
-        RootDestination.fromRoute(it)
-    }
-
-    if (currentRoute != destination) {
+    if (popTo != destination) {
         navigate(destination) {
             popUpTo(popTo) {
                 inclusive = true
@@ -81,6 +77,14 @@ private fun NavHostController.navigateToRootDestination(
     }
 }
 
+private val NavDestination.rootDestination: RootDestination?
+    get() = when {
+        hasRoute(RootDestination.Splash::class) -> RootDestination.Splash
+        hasRoute(RootDestination.Login::class) -> RootDestination.Login
+        hasRoute(RootDestination.Home::class) -> RootDestination.Home
+        else -> null
+    }
+
 internal sealed class RootDestination {
     @Serializable
     data object Splash : RootDestination()
@@ -90,15 +94,4 @@ internal sealed class RootDestination {
 
     @Serializable
     data object Home : RootDestination()
-
-    companion object {
-        fun fromRoute(route: String?): RootDestination? {
-            return when (route) {
-                Splash::class.qualifiedName -> Splash
-                Login::class.qualifiedName -> Login
-                Home::class.qualifiedName -> Home
-                else -> null
-            }
-        }
-    }
 }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/navigation/HomeNavigation.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/navigation/HomeNavigation.kt
@@ -54,8 +54,6 @@ internal sealed class HomeDestination(
     val labelRes: Int,
     val position: Int,
 ) {
-    val route: String =
-        this::class.qualifiedName ?: error("Route name is not defined for $this")
 
     @Serializable
     data object Gravatar : HomeDestination(

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/HomeScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/HomeScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
@@ -64,7 +65,7 @@ internal fun HomeScreen(
 ) {
     val navController = rememberNavController()
     val snackbarHostState = remember { SnackbarHostState() }
-    val backStackEntry = navController.currentBackStackEntryAsState()
+    val backStackEntry by navController.currentBackStackEntryAsState()
 
     Scaffold(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
@@ -83,9 +84,9 @@ internal fun HomeScreen(
                                     )
                                 },
                                 label = { Text(stringResource(destination.labelRes)) },
-                                selected = destination.route == backStackEntry.value?.destination?.route,
+                                selected = backStackEntry?.destination?.hasRoute(destination::class) == true,
                                 onClick = {
-                                    if (backStackEntry.value?.destination?.route != destination.route) {
+                                    if (backStackEntry?.destination?.hasRoute(destination::class) == false) {
                                         navController.navigate(destination) {
                                             popUpTo(navController.graph.startDestinationId) {
                                                 saveState = true


### PR DESCRIPTION
### Description

Two things are broken in the release build:
1. The back navigation after login/logout is wrong. The app should close rather than go back to the login screen and vice versa.
2. The selected tab's icon on the bottom nav bar is tinted.


The root cause is the usage of `::class.qualifiedName` when comparing the current navigation destination. With r8 in the release build, the code is obfuscated, and the name of the RootDestination or HomeDestination is different. 

This PR fixes this issue by using the API function from the Navigation library `hasRoute`.

Fixed issue number 1:

https://github.com/user-attachments/assets/f978d1c8-8602-4437-8494-9518c78ec690

and the icon tinting:

<img width="456" height="974" alt="Screenshot 2025-08-12 at 11 27 45" src="https://github.com/user-attachments/assets/c6f51588-ac2f-4111-b715-09f08f2d2464" />


### Testing Steps

1. Install the release build - you can do it from the Android Studio by changing the buildType to `release`. (Make sure you have the mobile secrets updated and applied to the project)
<img width="388" height="113" alt="Screenshot 2025-08-12 at 11 33 02" src="https://github.com/user-attachments/assets/eff3246b-7023-409f-8aa4-019fee5e7822" />

2. Log in
3. Log out
4. Use the system back button
5. Confirm the app is closed
6. Open the app again
7. Log in
8. Confirm the icon of the selected tab in the bottom bar is tinted
