### PR TITLE
Fix header overlay darkness on API 11 and lower 

### DIFF
--- a/design/build.gradle.kts
+++ b/design/build.gradle.kts
@@ -9,6 +9,7 @@ android {
 
 dependencies {
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.core.ktx)
 
     testImplementation(libs.junit)
     testImplementation(project(":testUtils"))

--- a/design/src/main/kotlin/com/gravatar/app/design/components/Screen.kt
+++ b/design/src/main/kotlin/com/gravatar/app/design/components/Screen.kt
@@ -1,0 +1,21 @@
+package com.gravatar.app.design.components
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+
+@Composable
+fun Screen(
+    appearanceLightStatusBars: Boolean = !isSystemInDarkTheme(),
+    content: @Composable () -> Unit,
+) {
+    val view = LocalView.current
+    SideEffect {
+        val window = (view.context as? android.app.Activity)?.window
+        val controller = window?.let { WindowCompat.getInsetsController(it, view) }
+        controller?.isAppearanceLightStatusBars = appearanceLightStatusBars
+    }
+    content()
+}

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/components/BlurredHeaderBackground.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/components/BlurredHeaderBackground.kt
@@ -1,12 +1,12 @@
 package com.gravatar.app.homeUi.presentation.home.components
 
+import android.os.Build
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.BlurredEdgeTreatment
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -27,8 +27,14 @@ internal fun BlurredHeaderBackground(
         Box(
             modifier = Modifier
                 .matchParentSize()
-                .background(Color.Black.copy(alpha = 0.15f))
+                .background(Color.Black.copy(alpha = scrimAlpha))
         )
         content()
     }
+}
+
+private val scrimAlpha = if (Build.VERSION.SDK_INT >= 32) {
+    0.15f
+} else {
+    0.6f
 }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/components/topbar/TopBarPickerPopup.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/components/topbar/TopBarPickerPopup.kt
@@ -52,13 +52,15 @@ internal fun TopBarPickerPopup(
         }
     }
 
-    TopBarPickerPopup(
-        anchorAlignment = anchorAlignment,
-        offset = offset,
-        onAboutAppClicked = onAboutAppClicked,
-        onDismissRequest = onDismissRequest,
-        onEvent = viewModel::onEvent
-    )
+    GravatarTheme {
+        TopBarPickerPopup(
+            anchorAlignment = anchorAlignment,
+            offset = offset,
+            onAboutAppClicked = onAboutAppClicked,
+            onDismissRequest = onDismissRequest,
+            onEvent = viewModel::onEvent
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
@@ -47,6 +47,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
+import com.gravatar.app.design.components.Screen
 import com.gravatar.app.design.components.snackbar.SnackbarType
 import com.gravatar.app.design.components.snackbar.showGravatarSnackbar
 import com.gravatar.app.design.theme.GravatarAppTheme
@@ -139,17 +140,21 @@ internal fun GravatarScreen(
         }
     }
 
-    GravatarScreen(
-        uiState = uiState,
-        onEvent = viewModel::onEvent,
-        onTakePictureClicked = takePhotoCallback,
-        onPickMediaClicked = {
-            if (!mediaPickerLaunched) {
-                pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
-                mediaPickerLaunched = true
-            }
-        },
-    )
+    Screen(
+        appearanceLightStatusBars = false
+    ) {
+        GravatarScreen(
+            uiState = uiState,
+            onEvent = viewModel::onEvent,
+            onTakePictureClicked = takePhotoCallback,
+            onPickMediaClicked = {
+                if (!mediaPickerLaunched) {
+                    pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+                    mediaPickerLaunched = true
+                }
+            },
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/components/GravatarHeader.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/components/GravatarHeader.kt
@@ -28,6 +28,7 @@ import androidx.constraintlayout.compose.ExperimentalMotionApi
 import androidx.constraintlayout.compose.MotionLayout
 import androidx.constraintlayout.compose.MotionScene
 import androidx.constraintlayout.compose.layoutId
+import com.gravatar.app.design.theme.GravatarAppTheme
 import com.gravatar.app.homeUi.R
 import com.gravatar.app.homeUi.presentation.home.components.BlurredHeaderBackground
 import com.gravatar.app.homeUi.presentation.home.components.GravatarAvatarWithShadow
@@ -59,55 +60,57 @@ internal fun GravatarHeader(
             .decodeToString()
     }
 
-    BlurredHeaderBackground(
-        avatarUrl = avatarUrl,
-        modifier = modifier.fillMaxWidth(),
-    ) {
-        MotionLayout(
-            motionScene = MotionScene(content = motionScene),
-            progress = progress,
-            modifier = modifier
-                .systemBarsPadding()
-                .fillMaxWidth()
-                .height(expandedHeight)
+    GravatarAppTheme(darkTheme = true) {
+        BlurredHeaderBackground(
+            avatarUrl = avatarUrl,
+            modifier = modifier.fillMaxWidth(),
         ) {
-            // Main circular avatar
-            GravatarAvatarWithShadow(
-                url = avatarUrl,
-                borderShape = CircleShape,
-                modifier = Modifier
-                    .layoutId("avatar1")
-            )
-
-            // Secondary square avatar
-            GravatarAvatarWithShadow(
-                url = avatarUrl,
-                borderShape = RoundedCornerShape(8.dp),
-                modifier = Modifier
-                    .layoutId("avatar2")
-            )
-
-            // Menu button
-            IconButton(
-                onClick = {
-                    topBarMenuVisible = true
-                },
-                modifier = Modifier
-                    .layoutId("menuButton")
+            MotionLayout(
+                motionScene = MotionScene(content = motionScene),
+                progress = progress,
+                modifier = modifier
+                    .systemBarsPadding()
+                    .fillMaxWidth()
+                    .height(expandedHeight)
             ) {
-                Image(
-                    painter = painterResource(id = R.drawable.more_button),
-                    contentDescription = stringResource(R.string.gravatar_tab_header_more_options),
+                // Main circular avatar
+                GravatarAvatarWithShadow(
+                    url = avatarUrl,
+                    borderShape = CircleShape,
+                    modifier = Modifier
+                        .layoutId("avatar1")
                 )
-            }
 
-            Box(modifier = Modifier.layoutId("menuPopup")) {
-                if (topBarMenuVisible) {
-                    TopBarPickerPopup(
-                        anchorAlignment = Alignment.End,
-                        onDismissRequest = { topBarMenuVisible = false },
-                        onAboutAppClicked = onAboutAppClicked
+                // Secondary square avatar
+                GravatarAvatarWithShadow(
+                    url = avatarUrl,
+                    borderShape = RoundedCornerShape(8.dp),
+                    modifier = Modifier
+                        .layoutId("avatar2")
+                )
+
+                // Menu button
+                IconButton(
+                    onClick = {
+                        topBarMenuVisible = true
+                    },
+                    modifier = Modifier
+                        .layoutId("menuButton")
+                ) {
+                    Image(
+                        painter = painterResource(id = R.drawable.more_button),
+                        contentDescription = stringResource(R.string.gravatar_tab_header_more_options),
                     )
+                }
+
+                Box(modifier = Modifier.layoutId("menuPopup")) {
+                    if (topBarMenuVisible) {
+                        TopBarPickerPopup(
+                            anchorAlignment = Alignment.End,
+                            onDismissRequest = { topBarMenuVisible = false },
+                            onAboutAppClicked = onAboutAppClicked
+                        )
+                    }
                 }
             }
         }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileScreen.kt
@@ -36,6 +36,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
+import com.gravatar.app.design.components.Screen
 import com.gravatar.app.design.components.snackbar.SnackbarType
 import com.gravatar.app.design.components.snackbar.showGravatarSnackbar
 import com.gravatar.app.homeUi.R
@@ -79,12 +80,16 @@ internal fun ProfileScreen(
         }
     }
 
-    ProfileScreen(
-        uiState = uiState,
-        onEvent = { event ->
-            viewModel.onEvent(profileEvent = event)
-        }
-    )
+    Screen(
+        appearanceLightStatusBars = false
+    ) {
+        ProfileScreen(
+            uiState = uiState,
+            onEvent = { event ->
+                viewModel.onEvent(profileEvent = event)
+            }
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/ShareScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/ShareScreen.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
+import com.gravatar.app.design.components.Screen
 import com.gravatar.app.design.theme.GravatarAppTheme
 import com.gravatar.app.homeUi.GravatarFileProvider
 import com.gravatar.app.homeUi.presentation.home.components.topbar.components.about.AboutAppDialog
@@ -73,12 +74,16 @@ internal fun ShareScreen(
         }
     }
 
-    ShareScreen(
-        uiState = uiState,
-        onEvent = { event ->
-            viewModel.onEvent(event)
-        }
-    )
+    Screen(
+        appearanceLightStatusBars = false
+    ) {
+        ShareScreen(
+            uiState = uiState,
+            onEvent = { event ->
+                viewModel.onEvent(event)
+            }
+        )
+    }
 }
 
 @Composable

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/components/ShareHeader.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/components/ShareHeader.kt
@@ -42,79 +42,81 @@ internal fun ShareHeader(
 ) {
     var topBarMenuVisible by remember { mutableStateOf(false) }
 
-    BlurredHeaderBackground(
-        avatarUrl = avatarUrl,
-        modifier = modifier.fillMaxWidth()
-    ) {
-        Row(
-            modifier = Modifier
-                .statusBarsPadding()
-                .padding(16.dp),
-            horizontalArrangement = Arrangement.spacedBy(22.dp),
-            verticalAlignment = Alignment.Top
+    GravatarAppTheme(darkTheme = true) {
+        BlurredHeaderBackground(
+            avatarUrl = avatarUrl,
+            modifier = modifier.fillMaxWidth()
         ) {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(16.dp),
+            Row(
                 modifier = Modifier
-                    .padding(top = 6.dp)
-                    .weight(1f),
+                    .statusBarsPadding()
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(22.dp),
+                verticalAlignment = Alignment.Top
             ) {
-                QrCode(vCardQrCodeData)
-                Text(
-                    text = stringResource(R.string.share_tab_scan_qr_code),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = Color.White,
-                )
-            }
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Box {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    modifier = Modifier
+                        .padding(top = 6.dp)
+                        .weight(1f),
+                ) {
+                    QrCode(vCardQrCodeData)
+                    Text(
+                        text = stringResource(R.string.share_tab_scan_qr_code),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = Color.White,
+                    )
+                }
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Box {
+                        IconButton(
+                            onClick = {
+                                topBarMenuVisible = true
+                            },
+                            modifier = Modifier
+                                .size(MENU_BUTTON_SIZE)
+                        ) {
+                            Image(
+                                painter = painterResource(id = R.drawable.more_button),
+                                contentDescription = stringResource(R.string.gravatar_tab_header_more_options),
+                            )
+                        }
+                        if (topBarMenuVisible) {
+                            TopBarPickerPopup(
+                                anchorAlignment = Alignment.End,
+                                offset = DpOffset(0.dp, 6.dp),
+                                onDismissRequest = { topBarMenuVisible = false },
+                                onAboutAppClicked = {
+                                    topBarMenuVisible = false
+                                    onAboutAppClicked()
+                                }
+                            )
+                        }
+                    }
                     IconButton(
                         onClick = {
-                            topBarMenuVisible = true
+                            onShareClick()
                         },
                         modifier = Modifier
                             .size(MENU_BUTTON_SIZE)
                     ) {
                         Image(
-                            painter = painterResource(id = R.drawable.more_button),
-                            contentDescription = stringResource(R.string.gravatar_tab_header_more_options),
+                            painter = painterResource(id = R.drawable.share_button),
+                            contentDescription = stringResource(R.string.share_tab_share_contact_information_button)
                         )
                     }
-                    if (topBarMenuVisible) {
-                        TopBarPickerPopup(
-                            anchorAlignment = Alignment.End,
-                            offset = DpOffset(0.dp, 6.dp),
-                            onDismissRequest = { topBarMenuVisible = false },
-                            onAboutAppClicked = {
-                                topBarMenuVisible = false
-                                onAboutAppClicked()
-                            }
+                    IconButton(
+                        onClick = {
+                            onExpandQrCodeClick()
+                        },
+                        modifier = Modifier
+                            .size(MENU_BUTTON_SIZE)
+                    ) {
+                        Image(
+                            painter = painterResource(id = R.drawable.expand_button),
+                            contentDescription = stringResource(R.string.share_tab_expand_qr_code)
                         )
                     }
-                }
-                IconButton(
-                    onClick = {
-                        onShareClick()
-                    },
-                    modifier = Modifier
-                        .size(MENU_BUTTON_SIZE)
-                ) {
-                    Image(
-                        painter = painterResource(id = R.drawable.share_button),
-                        contentDescription = stringResource(R.string.share_tab_share_contact_information_button)
-                    )
-                }
-                IconButton(
-                    onClick = {
-                        onExpandQrCodeClick()
-                    },
-                    modifier = Modifier
-                        .size(MENU_BUTTON_SIZE)
-                ) {
-                    Image(
-                        painter = painterResource(id = R.drawable.expand_button),
-                        contentDescription = stringResource(R.string.share_tab_expand_qr_code)
-                    )
                 }
             }
         }

--- a/loginUi/src/main/kotlin/com/gravatar/app/loginUi/presentation/login/LoginScreen.kt
+++ b/loginUi/src/main/kotlin/com/gravatar/app/loginUi/presentation/login/LoginScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
+import com.gravatar.app.design.components.Screen
 import com.gravatar.app.design.components.snackbar.GravatarSnackbarHost
 import com.gravatar.app.design.components.snackbar.SnackbarType
 import com.gravatar.app.design.components.snackbar.showGravatarSnackbar
@@ -54,9 +55,11 @@ import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun LoginScreen() {
-    LoginScreen(
-        viewModel = koinViewModel(),
-    )
+    Screen {
+        LoginScreen(
+            viewModel = koinViewModel(),
+        )
+    }
 }
 
 @Composable


### PR DESCRIPTION
### Description

The `.blur` Modifier we use to blur the header image works only on API 12 and higher. We have an additional overlay with `Color.Black(alpha = 0.15f)` but that wasn't enough without the blur. The first commit https://github.com/Automattic/Gravatar-Android/commit/ba92a807afe0fdcb94df6c95a16c28a1e8d34fc7 changes the alpha for Android 11 and lower.

Why not blur on older APIs? I've left a comment about this [here](https://linear.app/a8c/issue/GRA-487/blur-on-headers-is-not-working-as-expected-in-api-28#comment-c5ebf8ef). We should be able to add this, but the ProfileHeader needs some adjustments to make it look nice. 

| Before | After |
|---|---|
| <img width="1080" height="2160" alt="overlay_API_28_before" src="https://github.com/user-attachments/assets/8caf8b0a-8277-4b8e-a73f-324874a608be" /> | <img width="1080" height="2160" alt="overlay_API_28_after" src="https://github.com/user-attachments/assets/9e1ec8ad-f61d-463c-8ba8-703f80e4b704" /> |

This change made it more obvious that the status bar icons are not properly tinted. https://github.com/Automattic/Gravatar-Android/commit/019a7969942c851c4cb8149440509588ae6222e9 commit fixes that by setting a proper status bar appearance. I create a new `Screen` component that handles this logic, so each screen component should use this one as a wrapper now. This will come in handy for the Screen analytics events as well. 

| Before | After |
|---|---|
| <img width="1280" height="2856" alt="status_bar_before" src="https://github.com/user-attachments/assets/ea1f57b4-e450-45a7-9038-4ee444c53435" /> | <img width="1280" height="2856" alt="light_status_bar_after" src="https://github.com/user-attachments/assets/73ba0757-6fdb-4afa-82f8-b4f13fa1c268" /> |


Additionally, I've noticed that forcing a dark theme on the Profile header forces the dark theme on the `TopBarPickerPopup` component. This was fixed here as well.

| Before | After |
|---|---|
| <img width="1280" height="2856" alt="popup_menu_before" src="https://github.com/user-attachments/assets/96834a4d-4bb4-4b09-a4b9-911f0cff280c" /> | <img width="1280" height="2856" alt="popup_menu_after" src="https://github.com/user-attachments/assets/99a0f79c-21b5-4a4a-8489-71cd88c4f228" /> |

### Testing Steps

1. Launch the app on API 11 or lower and test the header overlay.
2. Switch the device to light mode and open the top menu in the app - confirm it uses light mode as well. 
3. Verify that the status bar icons are always white in the headers (Profile, Avatar and Share tabs), regardless of the device's dark/light mode. `LoginScreen` should set the appearance based on the device's color mode, the icons should change the color.
