### PR TITLE
Add `screen_view` and `screen_leave` analytic events

### DIFF
--- a/analytics/src/main/kotlin/com/gravatar/analytics/Event.kt
+++ b/analytics/src/main/kotlin/com/gravatar/analytics/Event.kt
@@ -4,10 +4,14 @@ import org.json.JSONObject
 
 interface Event {
     val name: String
-    val properties: Properties?
-        get() = null
+    val properties: Map<String, Any>
+        get() = emptyMap()
+}
 
-    interface Properties {
-        fun toJson(): JSONObject
+internal fun Map<String, Any>.asJson(): JSONObject {
+    return JSONObject().apply {
+        this@asJson.forEach { (key, value) ->
+            put(key, value)
+        }
     }
 }

--- a/analytics/src/main/kotlin/com/gravatar/analytics/Event.kt
+++ b/analytics/src/main/kotlin/com/gravatar/analytics/Event.kt
@@ -1,5 +1,13 @@
 package com.gravatar.analytics
 
+import org.json.JSONObject
+
 interface Event {
     val name: String
+    val properties: Properties?
+        get() = null
+
+    interface Properties {
+        fun toJson(): JSONObject
+    }
 }

--- a/analytics/src/main/kotlin/com/gravatar/analytics/tracks/TracksTracker.kt
+++ b/analytics/src/main/kotlin/com/gravatar/analytics/tracks/TracksTracker.kt
@@ -3,6 +3,7 @@ package com.gravatar.analytics.tracks
 import com.automattic.android.tracks.TracksClient
 import com.gravatar.analytics.Event
 import com.gravatar.analytics.Tracker
+import com.gravatar.analytics.asJson
 import java.util.UUID
 
 internal class TracksTracker(private val tracksClient: TracksClient) : Tracker() {
@@ -18,8 +19,12 @@ internal class TracksTracker(private val tracksClient: TracksClient) : Tracker()
         val userType = userId?.let {
             TracksClient.NosaraUserType.WPCOM
         } ?: TracksClient.NosaraUserType.ANON
-        val props = event.properties?.toJson()
-        tracksClient.track("${TRACKS_EVENT_NAME_PREFIX}${event.name}", props, userId ?: anonId, userType)
+        tracksClient.track(
+            "${TRACKS_EVENT_NAME_PREFIX}${event.name}",
+            event.properties.asJson(),
+            userId ?: anonId,
+            userType
+        )
     }
 
     override fun flush() {

--- a/analytics/src/main/kotlin/com/gravatar/analytics/tracks/TracksTracker.kt
+++ b/analytics/src/main/kotlin/com/gravatar/analytics/tracks/TracksTracker.kt
@@ -6,6 +6,11 @@ import com.gravatar.analytics.Tracker
 import java.util.UUID
 
 internal class TracksTracker(private val tracksClient: TracksClient) : Tracker() {
+
+    internal companion object {
+        const val TRACKS_EVENT_NAME_PREFIX = "gravatarandroid_"
+    }
+
     override var userId: String? = null
     private val anonId: String = generateNewAnonID()
 
@@ -13,7 +18,8 @@ internal class TracksTracker(private val tracksClient: TracksClient) : Tracker()
         val userType = userId?.let {
             TracksClient.NosaraUserType.WPCOM
         } ?: TracksClient.NosaraUserType.ANON
-        tracksClient.track(event.name, userId ?: anonId, userType)
+        val props = event.properties?.toJson()
+        tracksClient.track("${TRACKS_EVENT_NAME_PREFIX}${event.name}", props, userId ?: anonId, userType)
     }
 
     override fun flush() {

--- a/analytics/src/test/kotlin/com/gravatar/analytics/tracks/TrackTrackerTest.kt
+++ b/analytics/src/test/kotlin/com/gravatar/analytics/tracks/TrackTrackerTest.kt
@@ -30,7 +30,7 @@ class TrackTrackerTest {
         verify {
             mockClient.track(
                 "${TracksTracker.TRACKS_EVENT_NAME_PREFIX}${event.name}",
-                null,
+                any(),
                 any(),
                 TracksClient.NosaraUserType.ANON
             )
@@ -49,7 +49,7 @@ class TrackTrackerTest {
         verify {
             mockClient.track(
                 "${TracksTracker.TRACKS_EVENT_NAME_PREFIX}${event.name}",
-                null,
+                any(),
                 "someUserId",
                 TracksClient.NosaraUserType.WPCOM
             )

--- a/analytics/src/test/kotlin/com/gravatar/analytics/tracks/TrackTrackerTest.kt
+++ b/analytics/src/test/kotlin/com/gravatar/analytics/tracks/TrackTrackerTest.kt
@@ -27,7 +27,14 @@ class TrackTrackerTest {
 
         tracker.trackEvent(event)
 
-        verify { mockClient.track(event.name, any(), TracksClient.NosaraUserType.ANON) }
+        verify {
+            mockClient.track(
+                "${TracksTracker.TRACKS_EVENT_NAME_PREFIX}${event.name}",
+                null,
+                any(),
+                TracksClient.NosaraUserType.ANON
+            )
+        }
     }
 
     @Test
@@ -39,7 +46,14 @@ class TrackTrackerTest {
 
         tracker.trackEvent(event)
 
-        verify { mockClient.track(event.name, "someUserId", TracksClient.NosaraUserType.WPCOM) }
+        verify {
+            mockClient.track(
+                "${TracksTracker.TRACKS_EVENT_NAME_PREFIX}${event.name}",
+                null,
+                "someUserId",
+                TracksClient.NosaraUserType.WPCOM
+            )
+        }
     }
 
     @Test

--- a/design/build.gradle.kts
+++ b/design/build.gradle.kts
@@ -8,6 +8,11 @@ android {
 }
 
 dependencies {
+    implementation(project(":analytics"))
+
+    implementation(project.dependencies.platform(libs.koin.bom))
+    implementation(libs.koin.core)
+    implementation(libs.koin.compose)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.core.ktx)
 

--- a/design/src/main/kotlin/com/gravatar/app/design/analytics/DesignEvent.kt
+++ b/design/src/main/kotlin/com/gravatar/app/design/analytics/DesignEvent.kt
@@ -1,0 +1,27 @@
+package com.gravatar.app.design.analytics
+
+import com.gravatar.analytics.Event
+import org.json.JSONObject
+
+sealed class DesignEvent : Event {
+
+    data class ScreenView(val screen: String) : DesignEvent() {
+        override val name: String = "screen_view"
+        override val properties: Event.Properties? = ScreenViewProperties(screen)
+    }
+
+    data class ScreenLeave(val screen: String) : DesignEvent() {
+        override val name: String = "screen_leave"
+        override val properties: Event.Properties? = ScreenViewProperties(screen)
+    }
+}
+
+private class ScreenViewProperties(
+    val screen: String
+) : Event.Properties {
+    override fun toJson(): JSONObject {
+        return JSONObject().apply {
+            put("screen", screen)
+        }
+    }
+}

--- a/design/src/main/kotlin/com/gravatar/app/design/analytics/DesignEvent.kt
+++ b/design/src/main/kotlin/com/gravatar/app/design/analytics/DesignEvent.kt
@@ -1,27 +1,20 @@
 package com.gravatar.app.design.analytics
 
 import com.gravatar.analytics.Event
-import org.json.JSONObject
 
 sealed class DesignEvent : Event {
 
     data class ScreenView(val screen: String) : DesignEvent() {
         override val name: String = "screen_view"
-        override val properties: Event.Properties? = ScreenViewProperties(screen)
+        override val properties: Map<String, Any> = mapOf(
+            "screen" to screen,
+        )
     }
 
     data class ScreenLeave(val screen: String) : DesignEvent() {
         override val name: String = "screen_leave"
-        override val properties: Event.Properties? = ScreenViewProperties(screen)
-    }
-}
-
-private class ScreenViewProperties(
-    val screen: String
-) : Event.Properties {
-    override fun toJson(): JSONObject {
-        return JSONObject().apply {
-            put("screen", screen)
-        }
+        override val properties: Map<String, Any> = mapOf(
+            "screen" to screen,
+        )
     }
 }

--- a/design/src/main/kotlin/com/gravatar/app/design/components/Screen.kt
+++ b/design/src/main/kotlin/com/gravatar/app/design/components/Screen.kt
@@ -2,20 +2,40 @@ package com.gravatar.app.design.components
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
+import com.gravatar.analytics.Tracker
+import com.gravatar.app.design.analytics.DesignEvent
+import org.koin.compose.koinInject
 
 @Composable
 fun Screen(
+    screenName: String,
     appearanceLightStatusBars: Boolean = !isSystemInDarkTheme(),
     content: @Composable () -> Unit,
 ) {
+    val tracker = koinInject<Tracker>()
     val view = LocalView.current
     SideEffect {
         val window = (view.context as? android.app.Activity)?.window
         val controller = window?.let { WindowCompat.getInsetsController(it, view) }
         controller?.isAppearanceLightStatusBars = appearanceLightStatusBars
     }
+
+    // Track when the screen becomes visible
+    LaunchedEffect(screenName) {
+        tracker.trackEvent(DesignEvent.ScreenView(screenName))
+    }
+
+    // Track when the screen is no longer visible / disposed
+    DisposableEffect(screenName) {
+        onDispose {
+            tracker.trackEvent(DesignEvent.ScreenLeave(screenName))
+        }
+    }
+
     content()
 }

--- a/design/src/main/kotlin/com/gravatar/app/design/components/Screen.kt
+++ b/design/src/main/kotlin/com/gravatar/app/design/components/Screen.kt
@@ -3,7 +3,6 @@ package com.gravatar.app.design.components
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
@@ -25,13 +24,10 @@ fun Screen(
         controller?.isAppearanceLightStatusBars = appearanceLightStatusBars
     }
 
-    // Track when the screen becomes visible
-    LaunchedEffect(screenName) {
-        tracker.trackEvent(DesignEvent.ScreenView(screenName))
-    }
-
-    // Track when the screen is no longer visible / disposed
+    // Track when the screen becomes visible or is no longer visible
     DisposableEffect(screenName) {
+        tracker.trackEvent(DesignEvent.ScreenView(screenName))
+
         onDispose {
             tracker.trackEvent(DesignEvent.ScreenLeave(screenName))
         }

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/gravatar/GravatarScreen.kt
@@ -141,7 +141,8 @@ internal fun GravatarScreen(
     }
 
     Screen(
-        appearanceLightStatusBars = false
+        screenName = "avatars",
+        appearanceLightStatusBars = false,
     ) {
         GravatarScreen(
             uiState = uiState,

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/profile/ProfileScreen.kt
@@ -81,7 +81,8 @@ internal fun ProfileScreen(
     }
 
     Screen(
-        appearanceLightStatusBars = false
+        screenName = "profile",
+        appearanceLightStatusBars = false,
     ) {
         ProfileScreen(
             uiState = uiState,

--- a/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/ShareScreen.kt
+++ b/homeUi/src/main/kotlin/com/gravatar/app/homeUi/presentation/home/share/ShareScreen.kt
@@ -75,7 +75,8 @@ internal fun ShareScreen(
     }
 
     Screen(
-        appearanceLightStatusBars = false
+        screenName = "qr",
+        appearanceLightStatusBars = false,
     ) {
         ShareScreen(
             uiState = uiState,

--- a/loginUi/src/main/kotlin/com/gravatar/app/loginUi/presentation/login/LoginScreen.kt
+++ b/loginUi/src/main/kotlin/com/gravatar/app/loginUi/presentation/login/LoginScreen.kt
@@ -55,7 +55,7 @@ import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun LoginScreen() {
-    Screen {
+    Screen(screenName = "login") {
         LoginScreen(
             viewModel = koinViewModel(),
         )


### PR DESCRIPTION
### Description

This PR adds the properties to the Event class in the analytics module. Also, to verify that it works, I'm adding the `screen_view` and `screen_leave` events on the `Screen` composable.

This way, we can also work in parallel to add analytics, avoiding some conflicts.

### Testing Steps

- Verify you can see the events on `tracks` (you can use the filter `gravatarandroid%`)
- You can also verify that the event is tracked by adding a `flush` after each event and analyzing the network requests.